### PR TITLE
feat: eoa -> account naming with check interval config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Prometheus metrics exporter for Ethereum externally owned account and contract addresses including;
 
-- Externally owned account addresses
+- [Externally owned account and contract](https://ethereum.org/en/developers/docs/accounts) addresses
 - [ERC20](https://eips.ethereum.org/EIPS/eip-20) contracts
 - [ERC721](https://eips.ethereum.org/EIPS/eip-20) contracts
 - [ERC1155](https://eips.ethereum.org/EIPS/eip-20) contracts
@@ -32,14 +32,15 @@ Ethereum Address Metrics Exporter relies entirely on a single `yaml` config file
 | global.logging | `warn` | Log level (`panic`, `fatal`, `warn`, `info`, `debug`, `trace`) |
 | global.metricsAddr | `:9090` | The address the metrics server will listen on |
 | global.namespace | `eth_address` | The prefix added to every metric |
+| global.checkInterval | `15s` | How often the service should check the addresses for balance |
 | global.labels[] |  | Key value pair of labels to add to every metric (optional) |
 | execution.url | `http://localhost:8545` | URL to the execution node |
 | execution.timeout | `10s` | Timeout for requests to the execution node |
 | execution.headers[] |  | Key value pair of headers to add on every request |
-| addresses.eoa |  | List of ethereum externally owned account addresses |
-| addresses.eoa[].name |  | Name of the address, will be a label on the metric |
-| addresses.eoa[].address |  | Ethereum externally owned account address |
-| addresses.eoa[].labels[] |  | Key value pair of labels to add to this address only (optional) |
+| addresses.account |  | List of ethereum externally owned account or contract addresses |
+| addresses.account[].name |  | Name of the address, will be a label on the metric |
+| addresses.account[].address |  | Account address |
+| addresses.account[].labels[] |  | Key value pair of labels to add to this address only (optional) |
 | addresses.erc20 |  | List of ethereum [ERC20](https://eips.ethereum.org/EIPS/eip-20) addresses |
 | addresses.erc20[].name |  | Name of the address, will be a label on the metric |
 | addresses.erc20[].address |  | Ethereum address |
@@ -87,7 +88,7 @@ execution:
     authorization: "Basic abc123"
 
 addresses:
-  eoa:
+  account:
     - name: John smith
       address: 0x4B1D3c9BEf9D097F564DcD6cdF4558CB389bE3d5
       labels:

--- a/pkg/exporter/config.go
+++ b/pkg/exporter/config.go
@@ -17,10 +17,11 @@ type Config struct {
 }
 
 type GlobalConfig struct {
-	LoggingLevel string            `yaml:"logging" default:"warn"`
-	MetricsAddr  string            `yaml:"metricsAddr" default:":9090"`
-	Namespace    string            `yaml:"namespace" default:"eth_address"`
-	Labels       map[string]string `yaml:"labels"`
+	LoggingLevel  string            `yaml:"logging" default:"warn"`
+	MetricsAddr   string            `yaml:"metricsAddr" default:":9090"`
+	Namespace     string            `yaml:"namespace" default:"eth_address"`
+	CheckInterval time.Duration     `yaml:"checkInterval" default:"15s"`
+	Labels        map[string]string `yaml:"labels"`
 }
 
 // ExecutionNode represents a single ethereum execution client.
@@ -31,7 +32,7 @@ type ExecutionNode struct {
 }
 
 type Addresses struct {
-	EOA               []*jobs.AddressEOA               `yaml:"eoa"`
+	Account           []*jobs.AddressAccount           `yaml:"account"`
 	ERC20             []*jobs.AddressERC20             `yaml:"erc20"`
 	ERC721            []*jobs.AddressERC721            `yaml:"erc721"`
 	ERC1155           []*jobs.AddressERC1155           `yaml:"erc1155"`
@@ -40,12 +41,12 @@ type Addresses struct {
 }
 
 func (c *Config) Validate() error {
-	// Check that all addresses have different names
+	// Check that all account addresses have different names
 	duplicates := make(map[string]struct{})
-	for _, u := range c.Addresses.EOA {
+	for _, u := range c.Addresses.Account {
 		// Check that all addresses have different names
 		if _, ok := duplicates[u.Name]; ok {
-			return fmt.Errorf("there's a duplicate eoa addresses with the same name: %s", u.Name)
+			return fmt.Errorf("there's a duplicate account addresses with the same name: %s", u.Name)
 		}
 
 		duplicates[u.Name] = struct{}{}

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -44,7 +44,7 @@ func (e *exporter) Start(ctx context.Context) error {
 
 	e.execution = api.NewExecutionClient(e.log, e.Cfg.GlobalConfig.Namespace, e.Cfg.Execution.URL, e.Cfg.Execution.Headers, e.Cfg.Execution.Timeout)
 
-	e.metrics = NewMetrics(e.execution, e.log, e.Cfg.GlobalConfig.Namespace, e.Cfg.GlobalConfig.Labels, &e.Cfg.Addresses)
+	e.metrics = NewMetrics(e.execution, e.log, e.Cfg.GlobalConfig.CheckInterval, e.Cfg.GlobalConfig.Namespace, e.Cfg.GlobalConfig.Labels, &e.Cfg.Addresses)
 
 	e.log.
 		WithField("execution_url", e.Cfg.Execution.URL).


### PR DESCRIPTION
- Rename `EOA` to `Account` as addresses can be plain contracts (or proxy multi sig etc)
- Add global config to change check interval for addresses