### PR TITLE
feat: add ERC-4626 vault support and comprehensive test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A Prometheus metrics exporter for Ethereum externally owned account and contract
 - [ERC20](https://eips.ethereum.org/EIPS/eip-20) contracts
 - [ERC721](https://eips.ethereum.org/EIPS/eip-20) contracts
 - [ERC1155](https://eips.ethereum.org/EIPS/eip-20) contracts
+- [ERC4626](https://eips.ethereum.org/EIPS/eip-4626) tokenized vaults
 - [Uniswap pair](https://v2.info.uniswap.org/pairs) contracts
 - [Chainlink data feed](https://docs.chain.link/docs/data-feeds/price-feeds/addresses/?network=ethereum) contracts
 
@@ -57,6 +58,11 @@ Ethereum Address Metrics Exporter relies entirely on a single `yaml` config file
 | addresses.erc1155[].contract |  | Ethereum contract address |
 | addresses.erc1155[].tokenID |  | NFT Token Identifier |
 | addresses.erc1155[].labels[] |  | Key value pair of labels to add to this address only (optional) |
+| addresses.erc4626 |  | List of ethereum [ERC4626](https://eips.ethereum.org/EIPS/eip-4626) tokenized vault addresses |
+| addresses.erc4626[].name |  | Name of the vault, will be a label on the metric |
+| addresses.erc4626[].address |  | Ethereum address holding vault shares |
+| addresses.erc4626[].contract |  | Ethereum vault contract address |
+| addresses.erc4626[].labels[] |  | Key value pair of labels to add to this address only (optional) |
 | addresses.uniswapPair |  | List of [uniswap pair](https://v2.info.uniswap.org/pairs) addresses |
 | addresses.uniswapPair[].name |  | Name of the address, will be a label on the metric |
 | addresses.uniswapPair[].from |  | First symbol name, will be a label on the metric |
@@ -111,6 +117,12 @@ addresses:
       contract: 0x4B1D8DC12da8f658FA8BF0cdB18BB7D4dABB2DB3
       tokenID: 100
       address: 0x4B1D6D35f293AB699Bfc6DE141E031F3E3997BBe
+  erc4626:
+    - name: Morpho Value steakhouse USDC
+      contract: 0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB
+      address: 0x4B1D1465b14cA06e72b942F361Fd3352Aa9c5368
+      labels:
+        type: usdc
   # https://v2.info.uniswap.org/pairs
   uniswapPair:
     - name: eth->usdt

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -47,6 +47,14 @@ addresses:
       # optional metric labels to add to this address
       labels:
         extra: label
+  # https://ethereum.org/en/developers/docs/standards/tokens/erc-4626/
+  erc4626:
+    - name: Morpho Value steakhouse USDC
+      contract: 0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB
+      address: 0x4B1D6D35f293AB699Bfc6DE141E031F3E3997BBe
+      # optional metric labels to add to this address
+      labels:
+        type: usdc
   # https://v2.info.uniswap.org/pairs
   uniswapPair:
     - name: eth->usdt

--- a/pkg/exporter/config.go
+++ b/pkg/exporter/config.go
@@ -36,6 +36,7 @@ type Addresses struct {
 	ERC20             []*jobs.AddressERC20             `yaml:"erc20"`
 	ERC721            []*jobs.AddressERC721            `yaml:"erc721"`
 	ERC1155           []*jobs.AddressERC1155           `yaml:"erc1155"`
+	ERC4626           []*jobs.AddressERC4626           `yaml:"erc4626"`
 	UniswapPair       []*jobs.AddressUniswapPair       `yaml:"uniswapPair"`
 	ChainlinkDataFeed []*jobs.AddressChainlinkDataFeed `yaml:"chainlinkDataFeed"`
 }
@@ -87,6 +88,16 @@ func (c *Config) Validate() error {
 		// Check that all addresses have different names
 		if _, ok := duplicates[u.Name]; ok {
 			return fmt.Errorf("there's a duplicate uniswap pair addresses with the same name: %s", u.Name)
+		}
+
+		duplicates[u.Name] = struct{}{}
+	}
+
+	duplicates = make(map[string]struct{})
+	for _, u := range c.Addresses.ERC4626 {
+		// Check that all addresses have different names
+		if _, ok := duplicates[u.Name]; ok {
+			return fmt.Errorf("there's a duplicate erc4626 addresses with the same name: %s", u.Name)
 		}
 
 		duplicates[u.Name] = struct{}{}

--- a/pkg/exporter/jobs/account_test.go
+++ b/pkg/exporter/jobs/account_test.go
@@ -1,0 +1,182 @@
+package jobs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestAccount_getBalance(t *testing.T) {
+	tests := []struct {
+		name            string
+		address         *AddressAccount
+		balanceResponse string
+		balanceError    error
+		wantError       bool
+	}{
+		{
+			name: "successful balance retrieval",
+			address: &AddressAccount{
+				Name:    "Test Account",
+				Address: "0x1234567890123456789012345678901234567890",
+				Labels:  map[string]string{"type": "friend"},
+			},
+			balanceResponse: "0x0de0b6b3a7640000", // 1 ETH
+			wantError:       false,
+		},
+		{
+			name: "zero balance",
+			address: &AddressAccount{
+				Name:    "Empty Account",
+				Address: "0x0000000000000000000000000000000000000001",
+				Labels:  map[string]string{},
+			},
+			balanceResponse: "0x0",
+			wantError:       false,
+		},
+		{
+			name: "large balance",
+			address: &AddressAccount{
+				Name:    "Whale Account",
+				Address: "0x0000000000000000000000000000000000000002",
+				Labels:  map[string]string{},
+			},
+			balanceResponse: "0x56bc75e2d63100000", // 100 ETH
+			wantError:       false,
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockExecutionClient{
+				balanceOfResponse: tt.balanceResponse,
+				balanceOfError:    tt.balanceError,
+			}
+
+			// Override ETHGetBalance for account tests
+			mockClient.ethGetBalanceResponse = tt.balanceResponse
+			mockClient.ethGetBalanceError = tt.balanceError
+
+			log := logrus.New()
+			log.SetLevel(logrus.ErrorLevel)
+
+			namespace := string(rune('a' + i))
+
+			account := NewAccount(
+				mockClient,
+				log,
+				15*time.Second,
+				namespace,
+				map[string]string{},
+				[]*AddressAccount{tt.address},
+			)
+
+			err := account.getBalance(tt.address)
+
+			if (err != nil) != tt.wantError {
+				t.Errorf("getBalance() error = %v, wantError %v", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestAccount_tick(t *testing.T) {
+	mockClient := &mockExecutionClient{
+		ethGetBalanceResponse: "0x0de0b6b3a7640000",
+	}
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	addresses := []*AddressAccount{
+		{
+			Name:    "Account 1",
+			Address: "0x1111111111111111111111111111111111111111",
+			Labels:  map[string]string{},
+		},
+		{
+			Name:    "Account 2",
+			Address: "0x2222222222222222222222222222222222222222",
+			Labels:  map[string]string{},
+		},
+	}
+
+	account := NewAccount(
+		mockClient,
+		log,
+		15*time.Second,
+		"test_account_tick",
+		map[string]string{},
+		addresses,
+	)
+
+	ctx := context.Background()
+	account.tick(ctx)
+
+	// ETHGetBalance calls are tracked differently than ETHCall
+	// The mock should have been called for each address
+	if mockClient.ethGetBalanceCalls != len(addresses) {
+		t.Errorf("Expected %d ETHGetBalance calls, got %d", len(addresses), mockClient.ethGetBalanceCalls)
+	}
+}
+
+func TestAccount_getLabelValues(t *testing.T) {
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	addresses := []*AddressAccount{
+		{
+			Name:    "Test Account",
+			Address: "0x1234567890123456789012345678901234567890",
+			Labels: map[string]string{
+				"type":  "friend",
+				"extra": "custom",
+			},
+		},
+	}
+
+	account := NewAccount(
+		&mockExecutionClient{},
+		log,
+		15*time.Second,
+		"test_account_labels",
+		map[string]string{},
+		addresses,
+	)
+
+	labels := account.getLabelValues(addresses[0])
+
+	if len(labels) != len(account.labelsMap) {
+		t.Errorf("Expected %d label values, got %d", len(account.labelsMap), len(labels))
+	}
+
+	hasName := false
+	hasAddress := false
+
+	for _, label := range labels {
+		if label == addresses[0].Name {
+			hasName = true
+		}
+
+		if label == addresses[0].Address {
+			hasAddress = true
+		}
+	}
+
+	if !hasName {
+		t.Error("Label values should contain the name")
+	}
+
+	if !hasAddress {
+		t.Error("Label values should contain the address")
+	}
+}
+
+func TestAccount_Name(t *testing.T) {
+	account := &Account{}
+	if account.Name() != NameAccount {
+		t.Errorf("Expected name %s, got %s", NameAccount, account.Name())
+	}
+}

--- a/pkg/exporter/jobs/chainlink_data_feed_test.go
+++ b/pkg/exporter/jobs/chainlink_data_feed_test.go
@@ -1,0 +1,197 @@
+package jobs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestChainlinkDataFeed_getBalance(t *testing.T) {
+	tests := []struct {
+		name                 string
+		address              *AddressChainlinkDataFeed
+		latestAnswerResponse string
+		wantError            bool
+	}{
+		{
+			name: "successful price retrieval",
+			address: &AddressChainlinkDataFeed{
+				Name:     "ETH/USD",
+				From:     "eth",
+				To:       "usd",
+				Contract: "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+				Labels:   map[string]string{"type": "chainlink"},
+			},
+			latestAnswerResponse: "0x00000000000000000000000000000000000000000000000000000000773594c0", // ~2000 USD
+			wantError:            false,
+		},
+		{
+			name: "zero price",
+			address: &AddressChainlinkDataFeed{
+				Name:     "TEST/USD",
+				From:     "test",
+				To:       "usd",
+				Contract: "0x0000000000000000000000000000000000000001",
+				Labels:   map[string]string{},
+			},
+			latestAnswerResponse: "0x0000000000000000000000000000000000000000000000000000000000000000",
+			wantError:            false,
+		},
+		{
+			name: "high price",
+			address: &AddressChainlinkDataFeed{
+				Name:     "BTC/USD",
+				From:     "btc",
+				To:       "usd",
+				Contract: "0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c",
+				Labels:   map[string]string{},
+			},
+			latestAnswerResponse: "0x0000000000000000000000000000000000000000000000000000000ba43b7400", // ~50000 USD
+			wantError:            false,
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockExecutionClient{
+				latestAnswerResponse: tt.latestAnswerResponse,
+			}
+
+			log := logrus.New()
+			log.SetLevel(logrus.ErrorLevel)
+
+			namespace := "chainlink_" + string(rune('a'+i))
+
+			chainlink := NewChainlinkDataFeed(
+				mockClient,
+				log,
+				15*time.Second,
+				namespace,
+				map[string]string{},
+				[]*AddressChainlinkDataFeed{tt.address},
+			)
+
+			err := chainlink.getBalance(tt.address)
+
+			if (err != nil) != tt.wantError {
+				t.Errorf("getBalance() error = %v, wantError %v", err, tt.wantError)
+			}
+
+			// Verify latestAnswer call was made
+			if len(mockClient.callLog) != 1 {
+				t.Errorf("Expected 1 RPC call (latestAnswer), got %d", len(mockClient.callLog))
+			}
+
+			if len(mockClient.callLog) > 0 && mockClient.callLog[0].data[:10] != "0x50d25bcd" {
+				t.Errorf("Call should be latestAnswer (0x50d25bcd), got %s", mockClient.callLog[0].data[:10])
+			}
+		})
+	}
+}
+
+func TestChainlinkDataFeed_tick(t *testing.T) {
+	mockClient := &mockExecutionClient{
+		latestAnswerResponse: "0x00000000000000000000000000000000000000000000000000000000773594c0",
+		callLog:              []mockCall{},
+	}
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	addresses := []*AddressChainlinkDataFeed{
+		{
+			Name:     "ETH/USD",
+			From:     "eth",
+			To:       "usd",
+			Contract: "0x1111111111111111111111111111111111111111",
+			Labels:   map[string]string{},
+		},
+		{
+			Name:     "BTC/USD",
+			From:     "btc",
+			To:       "usd",
+			Contract: "0x2222222222222222222222222222222222222222",
+			Labels:   map[string]string{},
+		},
+	}
+
+	chainlink := NewChainlinkDataFeed(
+		mockClient,
+		log,
+		15*time.Second,
+		"test_chainlink_tick",
+		map[string]string{},
+		addresses,
+	)
+
+	ctx := context.Background()
+	chainlink.tick(ctx)
+
+	// Each address requires 1 call (latestAnswer)
+	expectedCalls := len(addresses)
+	if len(mockClient.callLog) != expectedCalls {
+		t.Errorf("Expected %d RPC calls, got %d", expectedCalls, len(mockClient.callLog))
+	}
+}
+
+func TestChainlinkDataFeed_getLabelValues(t *testing.T) {
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	addresses := []*AddressChainlinkDataFeed{
+		{
+			Name:     "ETH/USD",
+			From:     "eth",
+			To:       "usd",
+			Contract: "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+			Labels: map[string]string{
+				"type": "chainlink",
+			},
+		},
+	}
+
+	chainlink := NewChainlinkDataFeed(
+		&mockExecutionClient{},
+		log,
+		15*time.Second,
+		"test_chainlink_labels",
+		map[string]string{},
+		addresses,
+	)
+
+	labels := chainlink.getLabelValues(addresses[0])
+
+	if len(labels) != len(chainlink.labelsMap) {
+		t.Errorf("Expected %d label values, got %d", len(chainlink.labelsMap), len(labels))
+	}
+
+	hasFrom := false
+	hasTo := false
+
+	for _, label := range labels {
+		if label == addresses[0].From {
+			hasFrom = true
+		}
+
+		if label == addresses[0].To {
+			hasTo = true
+		}
+	}
+
+	if !hasFrom {
+		t.Error("Label values should contain the from symbol")
+	}
+
+	if !hasTo {
+		t.Error("Label values should contain the to symbol")
+	}
+}
+
+func TestChainlinkDataFeed_Name(t *testing.T) {
+	chainlink := &ChainlinkDataFeed{}
+	if chainlink.Name() != NameChainlinkDataFeed {
+		t.Errorf("Expected name %s, got %s", NameChainlinkDataFeed, chainlink.Name())
+	}
+}

--- a/pkg/exporter/jobs/erc1155_test.go
+++ b/pkg/exporter/jobs/erc1155_test.go
@@ -1,0 +1,195 @@
+package jobs
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestERC1155_getBalance(t *testing.T) {
+	tokenID := big.NewInt(100)
+
+	tests := []struct {
+		name            string
+		address         *AddressERC1155
+		balanceResponse string
+		wantError       bool
+	}{
+		{
+			name: "successful ERC1155 balance retrieval",
+			address: &AddressERC1155{
+				Name:     "Gaming NFT",
+				Address:  "0x1234567890123456789012345678901234567890",
+				Contract: "0x76BE3b62873462d2142405439777e971754E8E77",
+				TokenID:  *tokenID,
+				Labels:   map[string]string{"type": "gaming"},
+			},
+			balanceResponse: "0x000000000000000000000000000000000000000000000000000000000000000a", // 10 tokens
+			wantError:       false,
+		},
+		{
+			name: "zero balance",
+			address: &AddressERC1155{
+				Name:     "Empty Wallet",
+				Address:  "0x0000000000000000000000000000000000000001",
+				Contract: "0x76BE3b62873462d2142405439777e971754E8E77",
+				TokenID:  *tokenID,
+				Labels:   map[string]string{},
+			},
+			balanceResponse: "0x0000000000000000000000000000000000000000000000000000000000000000",
+			wantError:       false,
+		},
+		{
+			name: "large balance",
+			address: &AddressERC1155{
+				Name:     "Whale Wallet",
+				Address:  "0x0000000000000000000000000000000000000002",
+				Contract: "0x76BE3b62873462d2142405439777e971754E8E77",
+				TokenID:  *tokenID,
+				Labels:   map[string]string{},
+			},
+			balanceResponse: "0x00000000000000000000000000000000000000000000000000000000000003e8", // 1000 tokens
+			wantError:       false,
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockExecutionClient{
+				balanceOfResponse: tt.balanceResponse,
+			}
+
+			log := logrus.New()
+			log.SetLevel(logrus.ErrorLevel)
+
+			namespace := "erc1155_" + string(rune('a'+i))
+
+			erc1155 := NewERC1155(
+				mockClient,
+				log,
+				15*time.Second,
+				namespace,
+				map[string]string{},
+				[]*AddressERC1155{tt.address},
+			)
+
+			err := erc1155.getBalance(tt.address)
+
+			if (err != nil) != tt.wantError {
+				t.Errorf("getBalance() error = %v, wantError %v", err, tt.wantError)
+			}
+
+			// Verify balanceOf call was made
+			if len(mockClient.callLog) != 1 {
+				t.Errorf("Expected 1 RPC call (balanceOf), got %d", len(mockClient.callLog))
+			}
+
+			if len(mockClient.callLog) > 0 && mockClient.callLog[0].data[:10] != "0x00fdd58e" {
+				t.Errorf("Call should be balanceOf for ERC1155 (0x00fdd58e), got %s", mockClient.callLog[0].data[:10])
+			}
+		})
+	}
+}
+
+func TestERC1155_tick(t *testing.T) {
+	tokenID := big.NewInt(100)
+
+	mockClient := &mockExecutionClient{
+		balanceOfResponse: "0x0000000000000000000000000000000000000000000000000000000000000005",
+		callLog:           []mockCall{},
+	}
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	addresses := []*AddressERC1155{
+		{
+			Name:     "Token 1",
+			Address:  "0x1111111111111111111111111111111111111111",
+			Contract: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			TokenID:  *tokenID,
+			Labels:   map[string]string{},
+		},
+		{
+			Name:     "Token 2",
+			Address:  "0x2222222222222222222222222222222222222222",
+			Contract: "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+			TokenID:  *tokenID,
+			Labels:   map[string]string{},
+		},
+	}
+
+	erc1155 := NewERC1155(
+		mockClient,
+		log,
+		15*time.Second,
+		"test_erc1155_tick",
+		map[string]string{},
+		addresses,
+	)
+
+	ctx := context.Background()
+	erc1155.tick(ctx)
+
+	// Each address requires 1 call (balanceOf)
+	expectedCalls := len(addresses)
+	if len(mockClient.callLog) != expectedCalls {
+		t.Errorf("Expected %d RPC calls, got %d", expectedCalls, len(mockClient.callLog))
+	}
+}
+
+func TestERC1155_getLabelValues(t *testing.T) {
+	tokenID := big.NewInt(100)
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	addresses := []*AddressERC1155{
+		{
+			Name:     "Test ERC1155",
+			Address:  "0x1234567890123456789012345678901234567890",
+			Contract: "0x76BE3b62873462d2142405439777e971754E8E77",
+			TokenID:  *tokenID,
+			Labels: map[string]string{
+				"type": "gaming",
+			},
+		},
+	}
+
+	erc1155 := NewERC1155(
+		&mockExecutionClient{},
+		log,
+		15*time.Second,
+		"test_erc1155_labels",
+		map[string]string{},
+		addresses,
+	)
+
+	labels := erc1155.getLabelValues(addresses[0])
+
+	if len(labels) != len(erc1155.labelsMap) {
+		t.Errorf("Expected %d label values, got %d", len(erc1155.labelsMap), len(labels))
+	}
+
+	hasTokenID := false
+
+	for _, label := range labels {
+		if label == tokenID.String() {
+			hasTokenID = true
+		}
+	}
+
+	if !hasTokenID {
+		t.Error("Label values should contain the token ID")
+	}
+}
+
+func TestERC1155_Name(t *testing.T) {
+	erc1155 := &ERC1155{}
+	if erc1155.Name() != NameERC1155 {
+		t.Errorf("Expected name %s, got %s", NameERC1155, erc1155.Name())
+	}
+}

--- a/pkg/exporter/jobs/erc20_test.go
+++ b/pkg/exporter/jobs/erc20_test.go
@@ -1,0 +1,192 @@
+package jobs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestERC20_getBalance(t *testing.T) {
+	tests := []struct {
+		name            string
+		address         *AddressERC20
+		balanceResponse string
+		symbolResponse  string
+		wantError       bool
+	}{
+		{
+			name: "successful balance retrieval with symbol",
+			address: &AddressERC20{
+				Name:     "USDC Balance",
+				Address:  "0x1234567890123456789012345678901234567890",
+				Contract: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+				Labels:   map[string]string{"type": "stablecoin"},
+			},
+			balanceResponse: "0x0000000000000000000000000000000000000000000000000000000005f5e100", // 100 USDC (6 decimals)
+			symbolResponse:  "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000455534443000000000000000000000000000000000000000000000000000000",
+			wantError:       false,
+		},
+		{
+			name: "zero balance",
+			address: &AddressERC20{
+				Name:     "Empty Wallet",
+				Address:  "0x0000000000000000000000000000000000000001",
+				Contract: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+				Labels:   map[string]string{},
+			},
+			balanceResponse: "0x0000000000000000000000000000000000000000000000000000000000000000",
+			symbolResponse:  "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000455534443000000000000000000000000000000000000000000000000000000",
+			wantError:       false,
+		},
+		{
+			name: "large balance",
+			address: &AddressERC20{
+				Name:     "Whale Wallet",
+				Address:  "0x0000000000000000000000000000000000000002",
+				Contract: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+				Labels:   map[string]string{},
+			},
+			balanceResponse: "0x0000000000000000000000000000000000000000000000056bc75e2d63100000", // Large amount
+			symbolResponse:  "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000034441490000000000000000000000000000000000000000000000000000000000",
+			wantError:       false,
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockExecutionClient{
+				balanceOfResponse: tt.balanceResponse,
+				symbolResponse:    tt.symbolResponse,
+			}
+
+			log := logrus.New()
+			log.SetLevel(logrus.ErrorLevel)
+
+			namespace := "erc20_" + string(rune('a'+i))
+
+			erc20 := NewERC20(
+				mockClient,
+				log,
+				15*time.Second,
+				namespace,
+				map[string]string{},
+				[]*AddressERC20{tt.address},
+			)
+
+			err := erc20.getBalance(tt.address)
+
+			if (err != nil) != tt.wantError {
+				t.Errorf("getBalance() error = %v, wantError %v", err, tt.wantError)
+			}
+
+			// Verify both balanceOf and symbol calls were made
+			if len(mockClient.callLog) != 2 {
+				t.Errorf("Expected 2 RPC calls (balanceOf + symbol), got %d", len(mockClient.callLog))
+			}
+
+			if len(mockClient.callLog) > 0 && mockClient.callLog[0].data[:10] != "0x70a08231" {
+				t.Errorf("First call should be balanceOf (0x70a08231)")
+			}
+
+			if len(mockClient.callLog) > 1 && mockClient.callLog[1].data[:10] != "0x95d89b41" {
+				t.Errorf("Second call should be symbol (0x95d89b41)")
+			}
+		})
+	}
+}
+
+func TestERC20_tick(t *testing.T) {
+	mockClient := &mockExecutionClient{
+		balanceOfResponse: "0x0de0b6b3a7640000",
+		symbolResponse:    "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000455544800000000000000000000000000000000000000000000000000000000",
+		callLog:           []mockCall{},
+	}
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	addresses := []*AddressERC20{
+		{
+			Name:     "Token 1",
+			Address:  "0x1111111111111111111111111111111111111111",
+			Contract: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			Labels:   map[string]string{},
+		},
+		{
+			Name:     "Token 2",
+			Address:  "0x2222222222222222222222222222222222222222",
+			Contract: "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+			Labels:   map[string]string{},
+		},
+	}
+
+	erc20 := NewERC20(
+		mockClient,
+		log,
+		15*time.Second,
+		"test_erc20_tick",
+		map[string]string{},
+		addresses,
+	)
+
+	ctx := context.Background()
+	erc20.tick(ctx)
+
+	// Each address requires 2 calls (balanceOf + symbol)
+	expectedCalls := len(addresses) * 2
+	if len(mockClient.callLog) != expectedCalls {
+		t.Errorf("Expected %d RPC calls, got %d", expectedCalls, len(mockClient.callLog))
+	}
+}
+
+func TestERC20_getLabelValues(t *testing.T) {
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	addresses := []*AddressERC20{
+		{
+			Name:     "Test Token",
+			Address:  "0x1234567890123456789012345678901234567890",
+			Contract: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+			Labels: map[string]string{
+				"type": "stablecoin",
+			},
+		},
+	}
+
+	erc20 := NewERC20(
+		&mockExecutionClient{},
+		log,
+		15*time.Second,
+		"test_erc20_labels",
+		map[string]string{},
+		addresses,
+	)
+
+	labels := erc20.getLabelValues(addresses[0], "USDC")
+
+	if len(labels) != len(erc20.labelsMap) {
+		t.Errorf("Expected %d label values, got %d", len(erc20.labelsMap), len(labels))
+	}
+
+	hasSymbol := false
+
+	for _, label := range labels {
+		if label == "USDC" {
+			hasSymbol = true
+		}
+	}
+
+	if !hasSymbol {
+		t.Error("Label values should contain the symbol")
+	}
+}
+
+func TestERC20_Name(t *testing.T) {
+	erc20 := &ERC20{}
+	if erc20.Name() != NameERC20 {
+		t.Errorf("Expected name %s, got %s", NameERC20, erc20.Name())
+	}
+}

--- a/pkg/exporter/jobs/erc4626.go
+++ b/pkg/exporter/jobs/erc4626.go
@@ -1,0 +1,210 @@
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter/api"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+)
+
+// ERC4626 exposes metrics for ethereum ERC4626 vault contracts.
+type ERC4626 struct {
+	client        api.ExecutionClient
+	log           logrus.FieldLogger
+	ERC4626Assets prometheus.GaugeVec
+	ERC4626Error  prometheus.CounterVec
+	checkInterval time.Duration
+	addresses     []*AddressERC4626
+	labelsMap     map[string]int
+}
+
+type AddressERC4626 struct {
+	Address  string            `yaml:"address"`
+	Contract string            `yaml:"contract"`
+	Name     string            `yaml:"name"`
+	Labels   map[string]string `yaml:"labels"`
+}
+
+const (
+	NameERC4626 = "erc4626"
+)
+
+func (n *ERC4626) Name() string {
+	return NameERC4626
+}
+
+// NewERC4626 returns a new ERC4626 instance.
+func NewERC4626(client api.ExecutionClient, log logrus.FieldLogger, checkInterval time.Duration, namespace string, constLabels map[string]string, addresses []*AddressERC4626) ERC4626 {
+	namespace += "_" + NameERC4626
+
+	labelsMap := map[string]int{
+		LabelName:     0,
+		LabelAddress:  1,
+		LabelContract: 2,
+		LabelSymbol:   3,
+	}
+
+	for address := range addresses {
+		for label := range addresses[address].Labels {
+			if _, ok := labelsMap[label]; !ok {
+				labelsMap[label] = len(labelsMap)
+			}
+		}
+	}
+
+	labels := make([]string, len(labelsMap))
+	for label, index := range labelsMap {
+		labels[index] = label
+	}
+
+	instance := ERC4626{
+		client:        client,
+		log:           log.WithField("module", NameERC4626),
+		addresses:     addresses,
+		checkInterval: checkInterval,
+		labelsMap:     labelsMap,
+		ERC4626Assets: *prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace:   namespace,
+				Name:        "assets",
+				Help:        "The asset value from ERC4626 vault convertToAssets function.",
+				ConstLabels: constLabels,
+			},
+			labels,
+		),
+		ERC4626Error: *prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace:   namespace,
+				Name:        "errors_total",
+				Help:        "The total errors when calling ERC4626 vault functions.",
+				ConstLabels: constLabels,
+			},
+			labels,
+		),
+	}
+
+	prometheus.MustRegister(instance.ERC4626Assets)
+	prometheus.MustRegister(instance.ERC4626Error)
+
+	return instance
+}
+
+func (n *ERC4626) Start(ctx context.Context) {
+	n.tick(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(n.checkInterval):
+			n.tick(ctx)
+		}
+	}
+}
+
+//nolint:unparam // context will be used in the future
+func (n *ERC4626) tick(ctx context.Context) {
+	for _, address := range n.addresses {
+		err := n.getAssets(address)
+		if err != nil {
+			n.log.WithError(err).WithField("address", address).Error("Failed to get ERC4626 vault assets")
+		}
+	}
+}
+
+func (n *ERC4626) getLabelValues(address *AddressERC4626, symbol string) []string {
+	values := make([]string, len(n.labelsMap))
+
+	for label, index := range n.labelsMap {
+		if address.Labels != nil && address.Labels[label] != "" {
+			values[index] = address.Labels[label]
+		} else {
+			switch label {
+			case LabelName:
+				values[index] = address.Name
+			case LabelAddress:
+				values[index] = address.Address
+			case LabelContract:
+				values[index] = address.Contract
+			case LabelSymbol:
+				values[index] = symbol
+			default:
+				values[index] = LabelDefaultValue
+			}
+		}
+	}
+
+	return values
+}
+
+func (n *ERC4626) getAssets(address *AddressERC4626) error {
+	var err error
+
+	symbol := ""
+
+	defer func() {
+		if err != nil {
+			n.ERC4626Error.WithLabelValues(n.getLabelValues(address, symbol)...).Inc()
+		}
+	}()
+
+	// Step 1: Call balanceOf(address) on the vault contract to get shares balance
+	// Function selector for balanceOf(address) is 0x70a08231
+	balanceOfData := "0x70a08231000000000000000000000000" + address.Address[2:]
+
+	sharesStr, err := n.client.ETHCall(&api.ETHCallTransaction{
+		To:   address.Contract,
+		Data: &balanceOfData,
+	}, "latest")
+	if err != nil {
+		return err
+	}
+
+	// Extract the shares value (remove 0x prefix and ensure proper padding)
+	shares := strings.TrimPrefix(sharesStr, "0x")
+	if shares == "" {
+		shares = "0"
+	}
+
+	// Ensure shares is properly padded to 32 bytes (64 hex chars)
+	if len(shares) < 64 {
+		shares = fmt.Sprintf("%064s", shares)
+	}
+
+	// Step 2: Call convertToAssets(uint256 shares) on the vault contract
+	// Function selector for convertToAssets(uint256) is 0x07a2d13a
+	convertToAssetsData := "0x07a2d13a" + shares
+
+	assetsStr, err := n.client.ETHCall(&api.ETHCallTransaction{
+		To:   address.Contract,
+		Data: &convertToAssetsData,
+	}, "latest")
+	if err != nil {
+		return err
+	}
+
+	// Step 3: Call symbol() to get the vault token symbol
+	// Function selector for symbol() is 0x95d89b41
+	symbolData := "0x95d89b41000000000000000000000000"
+
+	symbolHex, err := n.client.ETHCall(&api.ETHCallTransaction{
+		To:   address.Contract,
+		Data: &symbolData,
+	}, "latest")
+	if err != nil {
+		return err
+	}
+
+	symbol, err = hexStringToString(symbolHex)
+	if err != nil {
+		return err
+	}
+
+	n.ERC4626Assets.WithLabelValues(n.getLabelValues(address, symbol)...).Set(hexStringToFloat64(assetsStr))
+
+	return nil
+}

--- a/pkg/exporter/jobs/erc4626_test.go
+++ b/pkg/exporter/jobs/erc4626_test.go
@@ -1,0 +1,363 @@
+package jobs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter/api"
+	"github.com/sirupsen/logrus"
+)
+
+// mockExecutionClient is a mock implementation of the ExecutionClient interface for testing.
+type mockExecutionClient struct {
+	balanceOfResponse       string
+	convertToAssetsResponse string
+	symbolResponse          string
+	getReservesResponse     string
+	latestAnswerResponse    string
+	balanceOfError          error
+	convertToAssetsError    error
+	symbolError             error
+	callLog                 []mockCall
+	ethGetBalanceResponse   string
+	ethGetBalanceError      error
+	ethGetBalanceCalls      int
+}
+
+type mockCall struct {
+	to   string
+	data string
+}
+
+func (m *mockExecutionClient) ETHCall(transaction *api.ETHCallTransaction, block string) (string, error) {
+	m.callLog = append(m.callLog, mockCall{
+		to:   transaction.To,
+		data: *transaction.Data,
+	})
+
+	// Check if this is a balanceOf call (0x70a08231)
+	if len(*transaction.Data) >= 10 && (*transaction.Data)[:10] == "0x70a08231" {
+		if m.balanceOfError != nil {
+			return "", m.balanceOfError
+		}
+
+		return m.balanceOfResponse, nil
+	}
+
+	// Check if this is a convertToAssets call (0x07a2d13a)
+	if len(*transaction.Data) >= 10 && (*transaction.Data)[:10] == "0x07a2d13a" {
+		if m.convertToAssetsError != nil {
+			return "", m.convertToAssetsError
+		}
+
+		return m.convertToAssetsResponse, nil
+	}
+
+	// Check if this is a symbol call (0x95d89b41)
+	if len(*transaction.Data) >= 10 && (*transaction.Data)[:10] == "0x95d89b41" {
+		if m.symbolError != nil {
+			return "", m.symbolError
+		}
+
+		if m.symbolResponse != "" {
+			return m.symbolResponse, nil
+		}
+
+		return "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000455544800000000000000000000000000000000000000000000000000000000", nil
+	}
+
+	// Check if this is a getReserves call (0x0902f1ac)
+	if len(*transaction.Data) >= 10 && (*transaction.Data)[:10] == "0x0902f1ac" {
+		if m.getReservesResponse != "" {
+			return m.getReservesResponse, nil
+		}
+
+		return "0x0000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000000000000000000000000000000de0b6b3a7640000", nil
+	}
+
+	// Check if this is a latestAnswer call (0x50d25bcd)
+	if len(*transaction.Data) >= 10 && (*transaction.Data)[:10] == "0x50d25bcd" {
+		if m.latestAnswerResponse != "" {
+			return m.latestAnswerResponse, nil
+		}
+
+		return "0x0000000000000000000000000000000000000000000000000000000000000000", nil
+	}
+
+	// Check if this is a balanceOf for ERC1155 (0x00fdd58e)
+	if len(*transaction.Data) >= 10 && (*transaction.Data)[:10] == "0x00fdd58e" {
+		if m.balanceOfError != nil {
+			return "", m.balanceOfError
+		}
+
+		return m.balanceOfResponse, nil
+	}
+
+	return "0x0", nil
+}
+
+func (m *mockExecutionClient) ETHGetBalance(address string, block string) (string, error) {
+	m.ethGetBalanceCalls++
+
+	if m.ethGetBalanceError != nil {
+		return "", m.ethGetBalanceError
+	}
+
+	if m.ethGetBalanceResponse != "" {
+		return m.ethGetBalanceResponse, nil
+	}
+
+	return "0x0", nil
+}
+
+func TestERC4626_getAssets(t *testing.T) {
+	tests := []struct {
+		name                    string
+		address                 *AddressERC4626
+		balanceOfResponse       string
+		convertToAssetsResponse string
+		balanceOfError          error
+		convertToAssetsError    error
+		wantError               bool
+	}{
+		{
+			name: "successful conversion with shares balance",
+			address: &AddressERC4626{
+				Name:     "Test Vault",
+				Address:  "0x1234567890123456789012345678901234567890",
+				Contract: "0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
+				Labels:   map[string]string{"type": "usdc"},
+			},
+			balanceOfResponse:       "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000", // 1e18
+			convertToAssetsResponse: "0x00000000000000000000000000000000000000000000000000038d7ea4c68000", // 1e15
+			wantError:               false,
+		},
+		{
+			name: "zero balance",
+			address: &AddressERC4626{
+				Name:     "Test Vault Zero",
+				Address:  "0x0000000000000000000000000000000000000001",
+				Contract: "0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
+				Labels:   map[string]string{},
+			},
+			balanceOfResponse:       "0x0000000000000000000000000000000000000000000000000000000000000000",
+			convertToAssetsResponse: "0x0000000000000000000000000000000000000000000000000000000000000000",
+			wantError:               false,
+		},
+		{
+			name: "large balance",
+			address: &AddressERC4626{
+				Name:     "Test Vault Large",
+				Address:  "0x0000000000000000000000000000000000000002",
+				Contract: "0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
+				Labels:   map[string]string{},
+			},
+			balanceOfResponse:       "0x0000000000000000000000000000000000000000000000056bc75e2d63100000",   // 1e20
+			convertToAssetsResponse: "0x0000000000000000000000000000000000000000000000152d02c7e14af6800000", // large number
+			wantError:               false,
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockExecutionClient{
+				balanceOfResponse:       tt.balanceOfResponse,
+				convertToAssetsResponse: tt.convertToAssetsResponse,
+				symbolResponse:          "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000973555344432d5661756c74000000000000000000000000000000000000000000", // "sUSDC-Vault"
+				balanceOfError:          tt.balanceOfError,
+				convertToAssetsError:    tt.convertToAssetsError,
+				callLog:                 []mockCall{},
+			}
+
+			log := logrus.New()
+			log.SetLevel(logrus.ErrorLevel)
+
+			// Use unique namespace for each test to avoid Prometheus registration conflicts
+			namespace := string(rune('a' + i))
+
+			erc4626 := NewERC4626(
+				mockClient,
+				log,
+				15*time.Second,
+				namespace,
+				map[string]string{},
+				[]*AddressERC4626{tt.address},
+			)
+
+			err := erc4626.getAssets(tt.address)
+
+			if (err != nil) != tt.wantError {
+				t.Errorf("getAssets() error = %v, wantError %v", err, tt.wantError)
+			}
+
+			// Verify that all three calls were made in the correct order
+			if len(mockClient.callLog) != 3 {
+				t.Errorf("Expected 3 RPC calls (balanceOf + convertToAssets + symbol), got %d", len(mockClient.callLog))
+			}
+
+			// Verify first call was balanceOf
+			if len(mockClient.callLog) > 0 {
+				firstCall := mockClient.callLog[0]
+				if firstCall.to != tt.address.Contract {
+					t.Errorf("First call should be to contract %s, got %s", tt.address.Contract, firstCall.to)
+				}
+
+				if len(firstCall.data) < 10 || firstCall.data[:10] != "0x70a08231" {
+					t.Errorf("First call should be balanceOf (0x70a08231), got %s", firstCall.data[:10])
+				}
+			}
+
+			// Verify second call was convertToAssets
+			if len(mockClient.callLog) > 1 {
+				secondCall := mockClient.callLog[1]
+				if secondCall.to != tt.address.Contract {
+					t.Errorf("Second call should be to contract %s, got %s", tt.address.Contract, secondCall.to)
+				}
+
+				if len(secondCall.data) < 10 || secondCall.data[:10] != "0x07a2d13a" {
+					t.Errorf("Second call should be convertToAssets (0x07a2d13a), got %s", secondCall.data[:10])
+				}
+			}
+
+			// Verify third call was symbol
+			if len(mockClient.callLog) > 2 {
+				thirdCall := mockClient.callLog[2]
+				if thirdCall.to != tt.address.Contract {
+					t.Errorf("Third call should be to contract %s, got %s", tt.address.Contract, thirdCall.to)
+				}
+
+				if len(thirdCall.data) < 10 || thirdCall.data[:10] != "0x95d89b41" {
+					t.Errorf("Third call should be symbol (0x95d89b41), got %s", thirdCall.data[:10])
+				}
+			}
+		})
+	}
+}
+
+func TestERC4626_tick(t *testing.T) {
+	mockClient := &mockExecutionClient{
+		balanceOfResponse:       "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+		convertToAssetsResponse: "0x00000000000000000000000000000000000000000000000000038d7ea4c68000",
+		symbolResponse:          "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000973555344432d5661756c74000000000000000000000000000000000000000000", // "sUSDC-Vault"
+		callLog:                 []mockCall{},
+	}
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	addresses := []*AddressERC4626{
+		{
+			Name:     "Vault 1",
+			Address:  "0x1111111111111111111111111111111111111111",
+			Contract: "0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
+			Labels:   map[string]string{},
+		},
+		{
+			Name:     "Vault 2",
+			Address:  "0x2222222222222222222222222222222222222222",
+			Contract: "0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
+			Labels:   map[string]string{},
+		},
+	}
+
+	erc4626 := NewERC4626(
+		mockClient,
+		log,
+		15*time.Second,
+		"test_tick",
+		map[string]string{},
+		addresses,
+	)
+
+	ctx := context.Background()
+	erc4626.tick(ctx)
+
+	// Verify that tick called getAssets for each address (2 addresses * 3 calls each = 6 total)
+	expectedCalls := len(addresses) * 3
+	if len(mockClient.callLog) != expectedCalls {
+		t.Errorf("Expected %d RPC calls for %d addresses, got %d", expectedCalls, len(addresses), len(mockClient.callLog))
+	}
+}
+
+func TestERC4626_getLabelValues(t *testing.T) {
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	addresses := []*AddressERC4626{
+		{
+			Name:     "Test Vault",
+			Address:  "0x1234567890123456789012345678901234567890",
+			Contract: "0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
+			Labels: map[string]string{
+				"type":  "usdc",
+				"extra": "custom",
+			},
+		},
+	}
+
+	erc4626 := NewERC4626(
+		&mockExecutionClient{
+			symbolResponse: "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000973555344432d5661756c74000000000000000000000000000000000000000000", // "sUSDC-Vault"
+		},
+		log,
+		15*time.Second,
+		"test_labels",
+		map[string]string{},
+		addresses,
+	)
+
+	labels := erc4626.getLabelValues(addresses[0], "sUSDC-Vault")
+
+	// Verify label values are populated correctly
+	if len(labels) != len(erc4626.labelsMap) {
+		t.Errorf("Expected %d label values, got %d", len(erc4626.labelsMap), len(labels))
+	}
+
+	// Verify standard labels are present
+	hasName := false
+	hasAddress := false
+	hasContract := false
+	hasSymbol := false
+
+	for _, label := range labels {
+		if label == addresses[0].Name {
+			hasName = true
+		}
+
+		if label == addresses[0].Address {
+			hasAddress = true
+		}
+
+		if label == addresses[0].Contract {
+			hasContract = true
+		}
+
+		if label == "sUSDC-Vault" {
+			hasSymbol = true
+		}
+	}
+
+	if !hasName {
+		t.Error("Label values should contain the name")
+	}
+
+	if !hasAddress {
+		t.Error("Label values should contain the address")
+	}
+
+	if !hasContract {
+		t.Error("Label values should contain the contract")
+	}
+
+	if !hasSymbol {
+		t.Error("Label values should contain the symbol")
+	}
+}
+
+func TestERC4626_Name(t *testing.T) {
+	erc4626 := &ERC4626{}
+	if erc4626.Name() != NameERC4626 {
+		t.Errorf("Expected name %s, got %s", NameERC4626, erc4626.Name())
+	}
+}

--- a/pkg/exporter/jobs/erc721_test.go
+++ b/pkg/exporter/jobs/erc721_test.go
@@ -1,0 +1,191 @@
+package jobs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestERC721_getBalance(t *testing.T) {
+	tests := []struct {
+		name            string
+		address         *AddressERC721
+		balanceResponse string
+		wantError       bool
+	}{
+		{
+			name: "successful NFT balance retrieval",
+			address: &AddressERC721{
+				Name:     "NFT Collection",
+				Address:  "0x1234567890123456789012345678901234567890",
+				Contract: "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
+				Labels:   map[string]string{"type": "bayc"},
+			},
+			balanceResponse: "0x0000000000000000000000000000000000000000000000000000000000000005", // 5 NFTs
+			wantError:       false,
+		},
+		{
+			name: "zero NFT balance",
+			address: &AddressERC721{
+				Name:     "Empty Wallet",
+				Address:  "0x0000000000000000000000000000000000000001",
+				Contract: "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
+				Labels:   map[string]string{},
+			},
+			balanceResponse: "0x0000000000000000000000000000000000000000000000000000000000000000",
+			wantError:       false,
+		},
+		{
+			name: "single NFT",
+			address: &AddressERC721{
+				Name:     "Single NFT Holder",
+				Address:  "0x0000000000000000000000000000000000000002",
+				Contract: "0x60E4d786628Fea6478F785A6d7e704777c86a7c6",
+				Labels:   map[string]string{},
+			},
+			balanceResponse: "0x0000000000000000000000000000000000000000000000000000000000000001",
+			wantError:       false,
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockExecutionClient{
+				balanceOfResponse: tt.balanceResponse,
+			}
+
+			log := logrus.New()
+			log.SetLevel(logrus.ErrorLevel)
+
+			namespace := "erc721_" + string(rune('a'+i))
+
+			erc721 := NewERC721(
+				mockClient,
+				log,
+				15*time.Second,
+				namespace,
+				map[string]string{},
+				[]*AddressERC721{tt.address},
+			)
+
+			err := erc721.getBalance(tt.address)
+
+			if (err != nil) != tt.wantError {
+				t.Errorf("getBalance() error = %v, wantError %v", err, tt.wantError)
+			}
+
+			// Verify balanceOf call was made
+			if len(mockClient.callLog) != 1 {
+				t.Errorf("Expected 1 RPC call (balanceOf), got %d", len(mockClient.callLog))
+			}
+
+			if len(mockClient.callLog) > 0 && mockClient.callLog[0].data[:10] != "0x70a08231" {
+				t.Errorf("Call should be balanceOf (0x70a08231)")
+			}
+		})
+	}
+}
+
+func TestERC721_tick(t *testing.T) {
+	mockClient := &mockExecutionClient{
+		balanceOfResponse: "0x0000000000000000000000000000000000000000000000000000000000000003",
+		callLog:           []mockCall{},
+	}
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	addresses := []*AddressERC721{
+		{
+			Name:     "NFT 1",
+			Address:  "0x1111111111111111111111111111111111111111",
+			Contract: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			Labels:   map[string]string{},
+		},
+		{
+			Name:     "NFT 2",
+			Address:  "0x2222222222222222222222222222222222222222",
+			Contract: "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+			Labels:   map[string]string{},
+		},
+	}
+
+	erc721 := NewERC721(
+		mockClient,
+		log,
+		15*time.Second,
+		"test_erc721_tick",
+		map[string]string{},
+		addresses,
+	)
+
+	ctx := context.Background()
+	erc721.tick(ctx)
+
+	// Each address requires 1 call (balanceOf)
+	expectedCalls := len(addresses)
+	if len(mockClient.callLog) != expectedCalls {
+		t.Errorf("Expected %d RPC calls, got %d", expectedCalls, len(mockClient.callLog))
+	}
+}
+
+func TestERC721_getLabelValues(t *testing.T) {
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	addresses := []*AddressERC721{
+		{
+			Name:     "Test NFT",
+			Address:  "0x1234567890123456789012345678901234567890",
+			Contract: "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
+			Labels: map[string]string{
+				"type": "bayc",
+			},
+		},
+	}
+
+	erc721 := NewERC721(
+		&mockExecutionClient{},
+		log,
+		15*time.Second,
+		"test_erc721_labels",
+		map[string]string{},
+		addresses,
+	)
+
+	labels := erc721.getLabelValues(addresses[0])
+
+	if len(labels) != len(erc721.labelsMap) {
+		t.Errorf("Expected %d label values, got %d", len(erc721.labelsMap), len(labels))
+	}
+
+	hasName := false
+	hasContract := false
+
+	for _, label := range labels {
+		if label == addresses[0].Name {
+			hasName = true
+		}
+
+		if label == addresses[0].Contract {
+			hasContract = true
+		}
+	}
+
+	if !hasName {
+		t.Error("Label values should contain the name")
+	}
+
+	if !hasContract {
+		t.Error("Label values should contain the contract")
+	}
+}
+
+func TestERC721_Name(t *testing.T) {
+	erc721 := &ERC721{}
+	if erc721.Name() != NameERC721 {
+		t.Errorf("Expected name %s, got %s", NameERC721, erc721.Name())
+	}
+}

--- a/pkg/exporter/jobs/uniswap_pair_test.go
+++ b/pkg/exporter/jobs/uniswap_pair_test.go
@@ -1,0 +1,185 @@
+package jobs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestUniswapPair_getBalance(t *testing.T) {
+	tests := []struct {
+		name                string
+		address             *AddressUniswapPair
+		getReservesResponse string
+		wantError           bool
+	}{
+		{
+			name: "successful reserves retrieval",
+			address: &AddressUniswapPair{
+				Name:     "ETH/USDT",
+				From:     "eth",
+				To:       "usdt",
+				Contract: "0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852",
+				Labels:   map[string]string{"type": "uniswap"},
+			},
+			getReservesResponse: "0x0000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000000000000000000000000000000de0b6b3a7640000", // Equal reserves
+			wantError:           false,
+		},
+		{
+			name: "unequal reserves",
+			address: &AddressUniswapPair{
+				Name:     "DAI/USDC",
+				From:     "dai",
+				To:       "usdc",
+				Contract: "0xAE461cA67B15dc8dc81CE7615e0320dA1A9aB8D5",
+				Labels:   map[string]string{},
+			},
+			getReservesResponse: "0x00000000000000000000000000000000000000000000000001bc16d674ec800000000000000000000000000000000000000000000000000000de0b6b3a7640000", // Different reserves
+			wantError:           false,
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockExecutionClient{
+				getReservesResponse: tt.getReservesResponse,
+			}
+
+			log := logrus.New()
+			log.SetLevel(logrus.ErrorLevel)
+
+			namespace := "uniswap_" + string(rune('a'+i))
+
+			uniswap := NewUniswapPair(
+				mockClient,
+				log,
+				15*time.Second,
+				namespace,
+				map[string]string{},
+				[]*AddressUniswapPair{tt.address},
+			)
+
+			err := uniswap.getBalance(tt.address)
+
+			if (err != nil) != tt.wantError {
+				t.Errorf("getBalance() error = %v, wantError %v", err, tt.wantError)
+			}
+
+			// Verify getReserves call was made
+			if len(mockClient.callLog) != 1 {
+				t.Errorf("Expected 1 RPC call (getReserves), got %d", len(mockClient.callLog))
+			}
+
+			if len(mockClient.callLog) > 0 && mockClient.callLog[0].data[:10] != "0x0902f1ac" {
+				t.Errorf("Call should be getReserves (0x0902f1ac), got %s", mockClient.callLog[0].data[:10])
+			}
+		})
+	}
+}
+
+func TestUniswapPair_tick(t *testing.T) {
+	mockClient := &mockExecutionClient{
+		getReservesResponse: "0x0000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000000000000000000000000000000de0b6b3a7640000",
+		callLog:             []mockCall{},
+	}
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	addresses := []*AddressUniswapPair{
+		{
+			Name:     "Pair 1",
+			From:     "eth",
+			To:       "usdt",
+			Contract: "0x1111111111111111111111111111111111111111",
+			Labels:   map[string]string{},
+		},
+		{
+			Name:     "Pair 2",
+			From:     "dai",
+			To:       "usdc",
+			Contract: "0x2222222222222222222222222222222222222222",
+			Labels:   map[string]string{},
+		},
+	}
+
+	uniswap := NewUniswapPair(
+		mockClient,
+		log,
+		15*time.Second,
+		"test_uniswap_tick",
+		map[string]string{},
+		addresses,
+	)
+
+	ctx := context.Background()
+	uniswap.tick(ctx)
+
+	// Each address requires 1 call (getReserves)
+	expectedCalls := len(addresses)
+	if len(mockClient.callLog) != expectedCalls {
+		t.Errorf("Expected %d RPC calls, got %d", expectedCalls, len(mockClient.callLog))
+	}
+}
+
+func TestUniswapPair_getLabelValues(t *testing.T) {
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	addresses := []*AddressUniswapPair{
+		{
+			Name:     "ETH/USDT",
+			From:     "eth",
+			To:       "usdt",
+			Contract: "0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852",
+			Labels: map[string]string{
+				"type": "uniswap",
+			},
+		},
+	}
+
+	uniswap := NewUniswapPair(
+		&mockExecutionClient{},
+		log,
+		15*time.Second,
+		"test_uniswap_labels",
+		map[string]string{},
+		addresses,
+	)
+
+	labels := uniswap.getLabelValues(addresses[0])
+
+	if len(labels) != len(uniswap.labelsMap) {
+		t.Errorf("Expected %d label values, got %d", len(uniswap.labelsMap), len(labels))
+	}
+
+	hasFrom := false
+	hasTo := false
+
+	for _, label := range labels {
+		if label == addresses[0].From {
+			hasFrom = true
+		}
+
+		if label == addresses[0].To {
+			hasTo = true
+		}
+	}
+
+	if !hasFrom {
+		t.Error("Label values should contain the from symbol")
+	}
+
+	if !hasTo {
+		t.Error("Label values should contain the to symbol")
+	}
+}
+
+func TestUniswapPair_Name(t *testing.T) {
+	uniswap := &UniswapPair{}
+	if uniswap.Name() != NameUniswapPair {
+		t.Errorf("Expected name %s, got %s", NameUniswapPair, uniswap.Name())
+	}
+}

--- a/pkg/exporter/metrics.go
+++ b/pkg/exporter/metrics.go
@@ -21,6 +21,7 @@ type metrics struct {
 	erc20Metrics             jobs.ERC20
 	erc721Metrics            jobs.ERC721
 	erc1155Metrics           jobs.ERC1155
+	erc4626Metrics           jobs.ERC4626
 	uniswapPairMetrics       jobs.UniswapPair
 	chainlinkDataFeedMetrics jobs.ChainlinkDataFeed
 
@@ -35,6 +36,7 @@ func NewMetrics(client api.ExecutionClient, log logrus.FieldLogger, checkInterva
 		erc20Metrics:             jobs.NewERC20(client, log, checkInterval, namespace, constLabels, addresses.ERC20),
 		erc721Metrics:            jobs.NewERC721(client, log, checkInterval, namespace, constLabels, addresses.ERC721),
 		erc1155Metrics:           jobs.NewERC1155(client, log, checkInterval, namespace, constLabels, addresses.ERC1155),
+		erc4626Metrics:           jobs.NewERC4626(client, log, checkInterval, namespace, constLabels, addresses.ERC4626),
 		uniswapPairMetrics:       jobs.NewUniswapPair(client, log, checkInterval, namespace, constLabels, addresses.UniswapPair),
 		chainlinkDataFeedMetrics: jobs.NewChainlinkDataFeed(client, log, checkInterval, namespace, constLabels, addresses.ChainlinkDataFeed),
 
@@ -57,6 +59,10 @@ func NewMetrics(client api.ExecutionClient, log logrus.FieldLogger, checkInterva
 
 	if len(addresses.ERC1155) > 0 {
 		m.enabledJobs[m.erc1155Metrics.Name()] = true
+	}
+
+	if len(addresses.ERC4626) > 0 {
+		m.enabledJobs[m.erc4626Metrics.Name()] = true
 	}
 
 	if len(addresses.UniswapPair) > 0 {
@@ -85,6 +91,10 @@ func (m *metrics) StartAsync(ctx context.Context) {
 
 	if m.enabledJobs[m.erc1155Metrics.Name()] {
 		go m.erc1155Metrics.Start(ctx)
+	}
+
+	if m.enabledJobs[m.erc4626Metrics.Name()] {
+		go m.erc4626Metrics.Start(ctx)
 	}
 
 	if m.enabledJobs[m.uniswapPairMetrics.Name()] {


### PR DESCRIPTION
Add ERC-4626 tokenized vault support:
- Implements balanceOf + convertToAssets for vault share tracking
- Automatically fetches user's vault share balance and converts to underlying assets
- Exports eth_address_erc4626_assets metric
- Includes contract address, user address, and custom labels

Add comprehensive unit tests for all jobs:
- Created test files for account, erc20, erc721, erc1155, erc4626, uniswap_pair, and chainlink_data_feed
- Implements shared mockExecutionClient supporting all RPC function selectors
- Tests cover zero/normal/large value scenarios, batch processing, and label validation
- All 28 tests passing with no external test dependencies

Configuration updates:
- Added erc4626 section to example_config.yaml
- Updated README with ERC-4626 documentation
- Added validation for duplicate ERC4626 names