### PR TITLE
feat: add ERC-4337 Account Abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Prometheus metrics exporter for Ethereum externally owned account and contract
 - [ERC721](https://eips.ethereum.org/EIPS/eip-20) contracts
 - [ERC1155](https://eips.ethereum.org/EIPS/eip-20) contracts
 - [ERC4626](https://eips.ethereum.org/EIPS/eip-4626) tokenized vaults
+- [ERC4337](https://eips.ethereum.org/EIPS/eip-4337) account abstraction
 - [Uniswap pair](https://v2.info.uniswap.org/pairs) contracts
 - [Chainlink data feed](https://docs.chain.link/docs/data-feeds/price-feeds/addresses/?network=ethereum) contracts
 
@@ -63,6 +64,11 @@ Ethereum Address Metrics Exporter relies entirely on a single `yaml` config file
 | addresses.erc4626[].address |  | Ethereum address holding vault shares |
 | addresses.erc4626[].contract |  | Ethereum vault contract address |
 | addresses.erc4626[].labels[] |  | Key value pair of labels to add to this address only (optional) |
+| addresses.erc4337 |  | List of ethereum [ERC4337](https://eips.ethereum.org/EIPS/eip-4337) account addresses |
+| addresses.erc4337[].name |  | Name of the account, will be a label on the metric |
+| addresses.erc4337[].address |  | Ethereum address of the account |
+| addresses.erc4337[].contract |  | Ethereum EntryPoint contract address |
+| addresses.erc4337[].labels[] |  | Key value pair of labels to add to this address only (optional) |
 | addresses.uniswapPair |  | List of [uniswap pair](https://v2.info.uniswap.org/pairs) addresses |
 | addresses.uniswapPair[].name |  | Name of the address, will be a label on the metric |
 | addresses.uniswapPair[].from |  | First symbol name, will be a label on the metric |
@@ -123,6 +129,12 @@ addresses:
       address: 0x4B1D1465b14cA06e72b942F361Fd3352Aa9c5368
       labels:
         type: usdc
+  erc4337:
+    - name: Some Paymaster
+      contract: 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789
+      address: 0x4B1D1465b14cA06e72b942F361Fd3352Aa9c5368
+      labels:
+        type: paymaster
   # https://v2.info.uniswap.org/pairs
   uniswapPair:
     - name: eth->usdt

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -55,6 +55,14 @@ addresses:
       # optional metric labels to add to this address
       labels:
         type: usdc
+  # https://eips.ethereum.org/EIPS/eip-4337
+  erc4337:
+    - name: Some Paymaster
+      contract: 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789
+      address: 0x4B1D1465b14cA06e72b942F361Fd3352Aa9c5368
+      # optional metric labels to add to this address
+      labels:
+        type: paymaster
   # https://v2.info.uniswap.org/pairs
   uniswapPair:
     - name: eth->usdt

--- a/pkg/exporter/config.go
+++ b/pkg/exporter/config.go
@@ -114,5 +114,15 @@ func (c *Config) Validate() error {
 		duplicates[u.Name] = struct{}{}
 	}
 
+	duplicates = make(map[string]struct{})
+	for _, u := range c.Addresses.ERC4337 {
+		// Check that all addresses have different names
+		if _, ok := duplicates[u.Name]; ok {
+			return fmt.Errorf("there's a duplicate erc4337 addresses with the same name: %s", u.Name)
+		}
+
+		duplicates[u.Name] = struct{}{}
+	}
+
 	return nil
 }

--- a/pkg/exporter/config.go
+++ b/pkg/exporter/config.go
@@ -39,6 +39,7 @@ type Addresses struct {
 	ERC4626           []*jobs.AddressERC4626           `yaml:"erc4626"`
 	UniswapPair       []*jobs.AddressUniswapPair       `yaml:"uniswapPair"`
 	ChainlinkDataFeed []*jobs.AddressChainlinkDataFeed `yaml:"chainlinkDataFeed"`
+	ERC4337           []*jobs.AddressERC4337           `yaml:"erc4337"`
 }
 
 func (c *Config) Validate() error {

--- a/pkg/exporter/jobs/erc4337.go
+++ b/pkg/exporter/jobs/erc4337.go
@@ -1,0 +1,163 @@
+package jobs
+
+import (
+	"context"
+	"time"
+
+	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter/api"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+)
+
+// ERC4337 exposes metrics for ethereum ERC4337 EntryPoint contract by address.
+type ERC4337 struct {
+	client         api.ExecutionClient
+	log            logrus.FieldLogger
+	ERC4337Balance prometheus.GaugeVec
+	ERC4337Error   prometheus.CounterVec
+	checkInterval  time.Duration
+	addresses      []*AddressERC4337
+	labelsMap      map[string]int
+}
+
+type AddressERC4337 struct {
+	Address  string            `yaml:"address"`
+	Contract string            `yaml:"contract"`
+	Name     string            `yaml:"name"`
+	Labels   map[string]string `yaml:"labels"`
+}
+
+const (
+	NameERC4337 = "erc4337"
+)
+
+func (n *ERC4337) Name() string {
+	return NameERC4337
+}
+
+// NewERC4337 returns a new ERC4337 instance.
+func NewERC4337(client api.ExecutionClient, log logrus.FieldLogger, checkInterval time.Duration, namespace string, constLabels map[string]string, addresses []*AddressERC4337) ERC4337 {
+	namespace += "_" + NameERC4337
+
+	labelsMap := map[string]int{
+		LabelName:     0,
+		LabelAddress:  1,
+		LabelContract: 2,
+	}
+
+	for address := range addresses {
+		for label := range addresses[address].Labels {
+			if _, ok := labelsMap[label]; !ok {
+				labelsMap[label] = len(labelsMap)
+			}
+		}
+	}
+
+	labels := make([]string, len(labelsMap))
+	for label, index := range labelsMap {
+		labels[index] = label
+	}
+
+	instance := ERC4337{
+		client:        client,
+		log:           log.WithField("module", NameERC4337),
+		addresses:     addresses,
+		checkInterval: checkInterval,
+		labelsMap:     labelsMap,
+		ERC4337Balance: *prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace:   namespace,
+				Name:        "balance",
+				Help:        "The deposit balance of a ethereum ERC4337 account in the EntryPoint contract.",
+				ConstLabels: constLabels,
+			},
+			labels,
+		),
+		ERC4337Error: *prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace:   namespace,
+				Name:        "errors_total",
+				Help:        "The total errors when getting the deposit balance of a ethereum ERC4337 account.",
+				ConstLabels: constLabels,
+			},
+			labels,
+		),
+	}
+
+	prometheus.MustRegister(instance.ERC4337Balance)
+	prometheus.MustRegister(instance.ERC4337Error)
+
+	return instance
+}
+
+func (n *ERC4337) Start(ctx context.Context) {
+	n.tick(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(n.checkInterval):
+			n.tick(ctx)
+		}
+	}
+}
+
+//nolint:unparam // context will be used in the future
+func (n *ERC4337) tick(ctx context.Context) {
+	for _, address := range n.addresses {
+		err := n.getBalance(address)
+		if err != nil {
+			n.log.WithError(err).WithField("address", address).Error("Failed to get erc4337 contract balanceOf address")
+		}
+	}
+}
+
+func (n *ERC4337) getLabelValues(address *AddressERC4337) []string {
+	values := make([]string, len(n.labelsMap))
+
+	for label, index := range n.labelsMap {
+		if address.Labels != nil && address.Labels[label] != "" {
+			values[index] = address.Labels[label]
+		} else {
+			switch label {
+			case LabelName:
+				values[index] = address.Name
+			case LabelAddress:
+				values[index] = address.Address
+			case LabelContract:
+				values[index] = address.Contract
+			default:
+				values[index] = LabelDefaultValue
+			}
+		}
+	}
+
+	return values
+}
+
+func (n *ERC4337) getBalance(address *AddressERC4337) error {
+	var err error
+
+	defer func() {
+		if err != nil {
+			n.ERC4337Error.WithLabelValues(n.getLabelValues(address)...).Inc()
+		}
+	}()
+
+	// call balanceOf(address) which is 0x70a08231
+	// This is the standard ERC20 balanceOf signature, which EntryPoint also uses for deposits
+	balanceOfData := "0x70a08231000000000000000000000000" + address.Address[2:]
+
+	balanceStr, err := n.client.ETHCall(&api.ETHCallTransaction{
+		To:   address.Contract,
+		Data: &balanceOfData,
+	}, "latest")
+	if err != nil {
+		return err
+	}
+
+	n.ERC4337Balance.WithLabelValues(n.getLabelValues(address)...).Set(hexStringToFloat64(balanceStr))
+
+	return nil
+}

--- a/pkg/exporter/jobs/erc4337_test.go
+++ b/pkg/exporter/jobs/erc4337_test.go
@@ -1,0 +1,159 @@
+package jobs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestERC4337_getBalance(t *testing.T) {
+	tests := []struct {
+		name            string
+		address         *AddressERC4337
+		balanceResponse string
+		wantError       bool
+	}{
+		{
+			name: "successful balance retrieval",
+			address: &AddressERC4337{
+				Name:     "Account 1",
+				Address:  "0x1234567890123456789012345678901234567890",
+				Contract: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789", // EntryPoint
+				Labels:   map[string]string{},
+			},
+			balanceResponse: "0x0000000000000000000000000000000000000000000000000000000005f5e100", // 100
+			wantError:       false,
+		},
+		{
+			name: "zero balance",
+			address: &AddressERC4337{
+				Name:     "Account 2",
+				Address:  "0x0000000000000000000000000000000000000001",
+				Contract: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+				Labels:   map[string]string{},
+			},
+			balanceResponse: "0x0000000000000000000000000000000000000000000000000000000000000000",
+			wantError:       false,
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockExecutionClient{
+				balanceOfResponse: tt.balanceResponse,
+			}
+
+			log := logrus.New()
+			log.SetLevel(logrus.ErrorLevel)
+
+			namespace := "erc4337_" + string(rune('a'+i))
+
+			erc4337 := NewERC4337(
+				mockClient,
+				log,
+				15*time.Second,
+				namespace,
+				map[string]string{},
+				[]*AddressERC4337{tt.address},
+			)
+
+			err := erc4337.getBalance(tt.address)
+
+			if (err != nil) != tt.wantError {
+				t.Errorf("getBalance() error = %v, wantError %v", err, tt.wantError)
+			}
+
+			// Verify balanceOf call was made
+			if len(mockClient.callLog) != 1 {
+				t.Errorf("Expected 1 RPC call (balanceOf), got %d", len(mockClient.callLog))
+			}
+
+			if len(mockClient.callLog) > 0 && mockClient.callLog[0].data[:10] != "0x70a08231" {
+				t.Errorf("First call should be balanceOf (0x70a08231)")
+			}
+		})
+	}
+}
+
+func TestERC4337_tick(t *testing.T) {
+	mockClient := &mockExecutionClient{
+		balanceOfResponse: "0x0de0b6b3a7640000",
+		callLog:           []mockCall{},
+	}
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	addresses := []*AddressERC4337{
+		{
+			Name:     "Account 1",
+			Address:  "0x1111111111111111111111111111111111111111",
+			Contract: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			Labels:   map[string]string{},
+		},
+		{
+			Name:     "Account 2",
+			Address:  "0x2222222222222222222222222222222222222222",
+			Contract: "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+			Labels:   map[string]string{},
+		},
+	}
+
+	erc4337 := NewERC4337(
+		mockClient,
+		log,
+		15*time.Second,
+		"test_erc4337_tick",
+		map[string]string{},
+		addresses,
+	)
+
+	ctx := context.Background()
+	erc4337.tick(ctx)
+
+	// Each address requires 1 call (balanceOf)
+	expectedCalls := len(addresses)
+	if len(mockClient.callLog) != expectedCalls {
+		t.Errorf("Expected %d RPC calls, got %d", expectedCalls, len(mockClient.callLog))
+	}
+}
+
+func TestERC4337_getLabelValues(t *testing.T) {
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	addresses := []*AddressERC4337{
+		{
+			Name:     "Test Account",
+			Address:  "0x1234567890123456789012345678901234567890",
+			Contract: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+			Labels: map[string]string{
+				"type": "paymaster",
+			},
+		},
+	}
+
+	erc4337 := NewERC4337(
+		&mockExecutionClient{},
+		log,
+		15*time.Second,
+		"test_erc4337_labels",
+		map[string]string{},
+		addresses,
+	)
+
+	labels := erc4337.getLabelValues(addresses[0])
+
+	if len(labels) != len(erc4337.labelsMap) {
+		t.Errorf("Expected %d label values, got %d", len(erc4337.labelsMap), len(labels))
+	}
+}
+
+func TestERC4337_Name(t *testing.T) {
+	erc4337 := &ERC4337{}
+	if erc4337.Name() != NameERC4337 {
+		t.Errorf("Expected name %s, got %s", NameERC4337, erc4337.Name())
+	}
+}

--- a/pkg/exporter/metrics.go
+++ b/pkg/exporter/metrics.go
@@ -24,6 +24,7 @@ type metrics struct {
 	erc4626Metrics           jobs.ERC4626
 	uniswapPairMetrics       jobs.UniswapPair
 	chainlinkDataFeedMetrics jobs.ChainlinkDataFeed
+	erc4337Metrics           jobs.ERC4337
 
 	enabledJobs map[string]bool
 }
@@ -39,6 +40,7 @@ func NewMetrics(client api.ExecutionClient, log logrus.FieldLogger, checkInterva
 		erc4626Metrics:           jobs.NewERC4626(client, log, checkInterval, namespace, constLabels, addresses.ERC4626),
 		uniswapPairMetrics:       jobs.NewUniswapPair(client, log, checkInterval, namespace, constLabels, addresses.UniswapPair),
 		chainlinkDataFeedMetrics: jobs.NewChainlinkDataFeed(client, log, checkInterval, namespace, constLabels, addresses.ChainlinkDataFeed),
+		erc4337Metrics:           jobs.NewERC4337(client, log, checkInterval, namespace, constLabels, addresses.ERC4337),
 
 		enabledJobs: make(map[string]bool),
 	}
@@ -73,6 +75,10 @@ func NewMetrics(client api.ExecutionClient, log logrus.FieldLogger, checkInterva
 		m.enabledJobs[m.chainlinkDataFeedMetrics.Name()] = true
 	}
 
+	if len(addresses.ERC4337) > 0 {
+		m.enabledJobs[m.erc4337Metrics.Name()] = true
+	}
+
 	return m
 }
 
@@ -103,6 +109,10 @@ func (m *metrics) StartAsync(ctx context.Context) {
 
 	if m.enabledJobs[m.chainlinkDataFeedMetrics.Name()] {
 		go m.chainlinkDataFeedMetrics.Start(ctx)
+	}
+
+	if m.enabledJobs[m.erc4337Metrics.Name()] {
+		go m.erc4337Metrics.Start(ctx)
 	}
 
 	m.log.Info("Started metrics exporter jobs")


### PR DESCRIPTION
Implements `balanceOf` to allow tracking balances of addresses (e.g. paymaster) within an `EntryPoint` as defined by [ERC-4337](https://eips.ethereum.org/EIPS/eip-4337).


Would be great if you can also bump the [ethereum-address-metrics-exporter chart](https://github.com/ethpandaops/ethereum-helm-charts/tree/master/charts/ethereum-address-metrics-exporter) when merged.

