### PR TITLE
feat: support multiple execution nodes with cross-node metrics

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,93 +1,109 @@
 version: "2"
+
 run:
-  issues-exit-code: 1
+  timeout: 5m
+
 linters:
   default: none
   enable:
-    - asasalint
     - bidichk
     - bodyclose
-    - containedctx
     - copyloopvar
-    - decorder
-    - dogsled
-    - durationcheck
+    - cyclop
+    - dupword
     - errcheck
     - errname
+    - errorlint
+    - exhaustive
+    - exptostd
+    - fatcontext
+    - funlen
     - goconst
-    - gocyclo
-    - godot
-    - goheader
-    - goprintffuncname
+    - gocognit
+    - gocritic
     - gosec
     - govet
     - ineffassign
+    - intrange
     - misspell
-    - nakedret
+    - modernize
+    - nestif
     - nilerr
-    - nilnil
-    - nlreturn
+    - noctx
     - nolintlint
-    - nosprintfhostport
-    - prealloc
+    - perfsprint
     - predeclared
-    - promlinter
-    - reassign
+    - revive
+    - sloglint
     - staticcheck
     - tagliatelle
-    - thelper
+    - testifylint
     - tparallel
     - unconvert
+    - usetesting
+    - unparam
     - unused
+    - usestdlibvars
+    - wastedassign
     - whitespace
-    - wsl_v5
+
   settings:
+    cyclop:
+      max-complexity: 30
+
+    funlen:
+      lines: 100
+      statements: 50
+
+    gocognit:
+      min-complexity: 20
+
     errcheck:
       check-type-assertions: true
-    goconst:
-      min-len: 2
-      min-occurrences: 3
-    gocritic:
-      enabled-tags:
-        - diagnostic
-        - experimental
-        - opinionated
-        - performance
-        - style
+
+    tagliatelle:
+      case:
+        rules:
+          yaml: camel
+          json: camel
+
+    revive:
+      rules:
+        - name: unexported-return
+          disabled: true
+
     govet:
-      enable:
-        - shadow
+      enable-all: true
+      disable:
+        - fieldalignment
+      settings:
+        shadow:
+          strict: true
+
     nolintlint:
       require-explanation: true
       require-specific: true
-    wsl_v5:
-      allow-first-in-block: true
-      allow-whole-block: false
-      branch-max-lines: 2
+
+    sloglint:
+      no-global: all
+      context: scope
+
+    staticcheck:
+      checks:
+        - all
+
   exclusions:
-    generated: lax
     presets:
       - comments
       - common-false-positives
       - legacy
       - std-error-handling
-    rules:
-      - linters:
-          - gocritic
-          - gosec
-          - wsl
-        path: _test\.go
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
+
 formatters:
   enable:
-    - gofmt
+    - gofumpt
     - goimports
-  exclusions:
-    generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/ethpandaops/ethereum-address-metrics-exporter

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for lab-backend
-FROM golang:1.25.1-alpine AS builder
+FROM golang:1.26.1-alpine AS builder
 
 RUN apk add --no-cache make git ca-certificates
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
-# 🦄 Ethereum Address Metrics Exporter 🦄
+# Ethereum Address Metrics Exporter
 
 A Prometheus metrics exporter for Ethereum externally owned account and contract addresses including;
 
 - [Externally owned account and contract](https://ethereum.org/en/developers/docs/accounts) addresses
 - [ERC20](https://eips.ethereum.org/EIPS/eip-20) contracts
-- [ERC721](https://eips.ethereum.org/EIPS/eip-20) contracts
-- [ERC1155](https://eips.ethereum.org/EIPS/eip-20) contracts
+- [ERC721](https://eips.ethereum.org/EIPS/eip-721) contracts
+- [ERC1155](https://eips.ethereum.org/EIPS/eip-1155) contracts
 - [ERC4626](https://eips.ethereum.org/EIPS/eip-4626) tokenized vaults
 - [ERC4337](https://eips.ethereum.org/EIPS/eip-4337) account abstraction
 - [Uniswap pair](https://v2.info.uniswap.org/pairs) contracts
 - [Chainlink data feed](https://docs.chain.link/docs/data-feeds/price-feeds/addresses/?network=ethereum) contracts
+
+## Multi-node support
+
+Multiple execution nodes can be configured. Every configured address is queried against **all** execution nodes on each tick. Each metric includes an `execution` label with the node name, enabling cross-node consensus checks in PromQL/Grafana.
 
 # Usage
 Ethereum Address Metrics Exporter requires a config file. An example file can be found [here](https://github.com/ethpandaops/ethereum-address-metrics-exporter/blob/master/example_config.yaml).
@@ -36,9 +40,10 @@ Ethereum Address Metrics Exporter relies entirely on a single `yaml` config file
 | global.namespace | `eth_address` | The prefix added to every metric |
 | global.checkInterval | `15s` | How often the service should check the addresses for balance |
 | global.labels[] |  | Key value pair of labels to add to every metric (optional) |
-| execution.url | `http://localhost:8545` | URL to the execution node |
-| execution.timeout | `10s` | Timeout for requests to the execution node |
-| execution.headers[] |  | Key value pair of headers to add on every request |
+| execution[].name |  | Unique name for the execution node (used as `execution` label) |
+| execution[].url | `http://localhost:8545` | URL to the execution node |
+| execution[].timeout | `10s` | Timeout for requests to the execution node |
+| execution[].headers[] |  | Key value pair of headers to add on every request |
 | addresses.account |  | List of ethereum externally owned account or contract addresses |
 | addresses.account[].name |  | Name of the address, will be a label on the metric |
 | addresses.account[].address |  | Account address |
@@ -94,10 +99,14 @@ global:
     extra: label
 
 execution:
-  url: "http://localhost:8545"
-  timeout: 10s
-  headers:
-    authorization: "Basic abc123"
+  - name: "geth-1"
+    url: "http://localhost:8545"
+    timeout: 10s
+    headers:
+      authorization: "Basic abc123"
+  - name: "nethermind-1"
+    url: "http://localhost:8546"
+    timeout: 10s
 
 addresses:
   account:
@@ -191,17 +200,17 @@ helm install ethereum-address-metrics-exporter ethereum-helm-charts/ethereum-add
    cd ./ethereum-address-metrics-exporter
    ```
 3. Build the binary
-   ```sh  
+   ```sh
     go build -o ethereum-address-metrics-exporter .
    ```
 4. Run the exporter
-   ```sh  
+   ```sh
     ./ethereum-address-metrics-exporter
    ```
 
 ## Contributing
 
-Contributions are greatly appreciated! Pull requests will be reviewed and merged promptly if you're interested in improving the exporter! 
+Contributions are greatly appreciated! Pull requests will be reviewed and merged promptly if you're interested in improving the exporter!
 
 1. Fork the project
 2. Create your feature branch:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,10 +4,11 @@ import (
 	"os"
 
 	"github.com/creasty/defaults"
-	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
+
+	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter"
 )
 
 // rootCmd represents the base command when called without any subcommands.
@@ -60,8 +61,8 @@ func loadConfigFromFile(file string) (*exporter.Config, error) {
 
 	type plain exporter.Config
 
-	if err := yaml.Unmarshal(yamlFile, (*plain)(cfg)); err != nil {
-		return nil, err
+	if unmarshalErr := yaml.Unmarshal(yamlFile, (*plain)(cfg)); unmarshalErr != nil {
+		return nil, unmarshalErr
 	}
 
 	return cfg, nil

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -7,13 +7,17 @@ global:
     extra: label
 
 execution:
-  url: "http://localhost:8545"
-  timeout: 10s
-  headers:
-    authorization: "Basic abc123"
+  - name: "geth-1"
+    url: "http://localhost:8545"
+    timeout: 10s
+    headers:
+      authorization: "Basic abc123"
+  - name: "nethermind-1"
+    url: "http://localhost:8546"
+    timeout: 10s
 
 addresses:
-  contract:
+  account:
     - name: John smith
       address: 0x4B1D3c9BEf9D097F564DcD6cdF4558CB389bE3d5
       # optional metric labels to add to this address

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethpandaops/ethereum-address-metrics-exporter
 
-go 1.25
+go 1.26.1
 
 // replace github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter => ./pkg/ethereum-address-metrics-exporter
 
@@ -9,15 +9,19 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.10.1
+	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
@@ -25,4 +29,5 @@ require (
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/sys v0.37.0 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/exporter/api/api.go
+++ b/pkg/exporter/api/api.go
@@ -2,10 +2,13 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -13,12 +16,15 @@ import (
 
 // ExecutionClient is an interface for executing RPC calls to the Ethereum node.
 type ExecutionClient interface {
+	// Name returns the configured name of this execution client.
+	Name() string
 	// ETHCall executes a new message call immediately without creating a transaction on the block chain.
-	ETHCall(transaction *ETHCallTransaction, block string) (string, error)
+	ETHCall(ctx context.Context, transaction *ETHCallTransaction, block string) (string, error)
 	// ETHGetBalance returns the balance of the account of given address.
-	ETHGetBalance(address string, block string) (string, error)
+	ETHGetBalance(ctx context.Context, address string, block string) (string, error)
 }
 
+// ETHCallTransaction represents an eth_call transaction object.
 type ETHCallTransaction struct {
 	From     *string `json:"from"`
 	To       string  `json:"to"`
@@ -29,7 +35,9 @@ type ETHCallTransaction struct {
 }
 
 type executionClient struct {
+	name    string
 	url     string
+	path    string
 	log     logrus.FieldLogger
 	client  http.Client
 	headers map[string]string
@@ -37,20 +45,34 @@ type executionClient struct {
 	metrics Metrics
 }
 
-// NewExecutionClient creates a new ExecutionClient.
-func NewExecutionClient(log logrus.FieldLogger, namespace, url string, headers map[string]string, timeout time.Duration) ExecutionClient {
+// NewExecutionClient creates a new ExecutionClient. The provided Metrics
+// instance is shared across all clients so each call must not register its
+// own collectors with Prometheus.
+func NewExecutionClient(log logrus.FieldLogger, metrics Metrics, name, rawURL string, headers map[string]string, timeout time.Duration) ExecutionClient {
 	client := http.Client{
 		Timeout: timeout,
 	}
 
+	path := "/"
+	if parsed, err := url.Parse(rawURL); err == nil && parsed.Path != "" {
+		path = parsed.Path
+	}
+
 	return &executionClient{
-		url:     url,
+		name:    name,
+		url:     rawURL,
+		path:    path,
 		log:     log,
 		client:  client,
 		headers: headers,
 
-		metrics: NewMetrics(fmt.Sprintf("%s_%s", namespace, "http")),
+		metrics: metrics,
 	}
+}
+
+// Name returns the configured name of this execution client.
+func (e *executionClient) Name() string {
+	return e.name
 }
 
 type apiResponse struct {
@@ -59,13 +81,12 @@ type apiResponse struct {
 	Result  json.RawMessage `json:"result"`
 }
 
-//nolint:unparam // ctx will probably be used in the future
-func (e *executionClient) post(method string, params interface{}, id int) (json.RawMessage, error) {
+func (e *executionClient) post(ctx context.Context, method string, params any, id int) (json.RawMessage, error) {
 	start := time.Now()
 
 	httpMethod := "POST"
 
-	e.metrics.ObserveRequest(httpMethod, e.url, method)
+	e.metrics.ObserveRequest(httpMethod, e.path, method, e.name)
 
 	var rsp *http.Response
 
@@ -74,13 +95,13 @@ func (e *executionClient) post(method string, params interface{}, id int) (json.
 	defer func() {
 		rspCode := "none"
 		if rsp != nil {
-			rspCode = fmt.Sprintf("%d", rsp.StatusCode)
+			rspCode = strconv.Itoa(rsp.StatusCode)
 		}
 
-		e.metrics.ObserveResponse(httpMethod, e.url, method, rspCode, time.Since(start))
+		e.metrics.ObserveResponse(httpMethod, e.path, method, rspCode, e.name, time.Since(start))
 	}()
 
-	body := map[string]interface{}{
+	body := map[string]any{
 		"jsonrpc": "2.0",
 		"method":  method,
 		"id":      id,
@@ -92,7 +113,7 @@ func (e *executionClient) post(method string, params interface{}, id int) (json.
 		return nil, err
 	}
 
-	req, err := http.NewRequest(httpMethod, e.url, bytes.NewBuffer(jsonData))
+	req, err := http.NewRequestWithContext(ctx, httpMethod, e.url, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return nil, err
 	}
@@ -120,46 +141,49 @@ func (e *executionClient) post(method string, params interface{}, id int) (json.
 	}
 
 	resp := new(apiResponse)
-	if err := json.Unmarshal(data, resp); err != nil {
-		return nil, err
+
+	if unmarshalErr := json.Unmarshal(data, resp); unmarshalErr != nil {
+		return nil, unmarshalErr
 	}
 
 	return resp.Result, nil
 }
 
-func (e *executionClient) ETHCall(transaction *ETHCallTransaction, block string) (string, error) {
-	params := []interface{}{
+func (e *executionClient) ETHCall(ctx context.Context, transaction *ETHCallTransaction, block string) (string, error) {
+	params := []any{
 		transaction,
 		block,
 	}
 
-	rsp, err := e.post("eth_call", params, 1)
+	rsp, err := e.post(ctx, "eth_call", params, 1)
 	if err != nil {
 		return "", err
 	}
 
 	ethCall := ""
-	if err := json.Unmarshal(rsp, &ethCall); err != nil {
-		return "", err
+
+	if unmarshalErr := json.Unmarshal(rsp, &ethCall); unmarshalErr != nil {
+		return "", unmarshalErr
 	}
 
 	return ethCall, nil
 }
 
-func (e *executionClient) ETHGetBalance(address, block string) (string, error) {
-	params := []interface{}{
+func (e *executionClient) ETHGetBalance(ctx context.Context, address, block string) (string, error) {
+	params := []any{
 		address,
 		block,
 	}
 
-	rsp, err := e.post("eth_getBalance", params, 1)
+	rsp, err := e.post(ctx, "eth_getBalance", params, 1)
 	if err != nil {
 		return "", err
 	}
 
 	ethGetBalance := ""
-	if err := json.Unmarshal(rsp, &ethGetBalance); err != nil {
-		return "", err
+
+	if unmarshalErr := json.Unmarshal(rsp, &ethGetBalance); unmarshalErr != nil {
+		return "", unmarshalErr
 	}
 
 	return ethGetBalance, nil

--- a/pkg/exporter/api/api_test.go
+++ b/pkg/exporter/api/api_test.go
@@ -1,0 +1,243 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type rpcRequest struct {
+	JSONRPC string `json:"jsonrpc"`
+	Method  string `json:"method"`
+	ID      int    `json:"id"`
+	Params  []any  `json:"params"`
+}
+
+var testClientCounter atomic.Int64
+
+func newTestServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+func newTestClient(t *testing.T, name, url string) ExecutionClient {
+	t.Helper()
+
+	n := testClientCounter.Add(1)
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	namespace := "test_" + strconv.FormatInt(n, 10)
+
+	return NewExecutionClient(log, NewMetrics(namespace), name, url, nil, 5*time.Second)
+}
+
+func TestExecutionClient_Name(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, "geth-1", "http://unused")
+	assert.Equal(t, "geth-1", client.Name())
+}
+
+func TestExecutionClient_ETHGetBalance(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		handler    http.HandlerFunc
+		wantResult string
+		wantErr    bool
+	}{
+		{
+			name: "successful balance response",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+
+				var req rpcRequest
+				if err := json.Unmarshal(body, &req); err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":"0xde0b6b3a7640000"}`))
+			},
+			wantResult: "0xde0b6b3a7640000",
+		},
+		{
+			name: "http 500 error",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			wantErr: true,
+		},
+		{
+			name: "malformed json response",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{invalid json`))
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty result",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":"0x0"}`))
+			},
+			wantResult: "0x0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := newTestServer(t, tt.handler)
+			client := newTestClient(t, "test-node", server.URL)
+
+			result, err := client.ETHGetBalance(context.Background(), "0x1234567890123456789012345678901234567890", "latest")
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantResult, result)
+			}
+		})
+	}
+}
+
+func TestExecutionClient_ETHCall(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		handler    http.HandlerFunc
+		wantResult string
+		wantErr    bool
+	}{
+		{
+			name: "successful eth_call",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+
+				var req rpcRequest
+				if err := json.Unmarshal(body, &req); err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+
+				assert.Equal(t, "eth_call", req.Method)
+
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":"0x0000000000000000000000000000000000000000000000000000000005f5e100"}`))
+			},
+			wantResult: "0x0000000000000000000000000000000000000000000000000000000005f5e100",
+		},
+		{
+			name: "http 400 bad request",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := newTestServer(t, tt.handler)
+			client := newTestClient(t, "test-node", server.URL)
+
+			data := "0x70a08231000000000000000000000000aabbccdd"
+			result, err := client.ETHCall(context.Background(), &ETHCallTransaction{
+				To:   "0xcontract",
+				Data: &data,
+			}, "latest")
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantResult, result)
+			}
+		})
+	}
+}
+
+func TestExecutionClient_CustomHeaders(t *testing.T) {
+	t.Parallel()
+
+	var receivedAuth string
+
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":"0x0"}`))
+	})
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	n := testClientCounter.Add(1)
+	namespace := "test_headers_" + strconv.FormatInt(n, 10)
+
+	headers := map[string]string{
+		"Authorization": "Bearer test-token",
+	}
+
+	client := NewExecutionClient(log, NewMetrics(namespace), "node-1", server.URL, headers, 5*time.Second)
+
+	_, err := client.ETHGetBalance(context.Background(), "0x1234567890123456789012345678901234567890", "latest")
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer test-token", receivedAuth)
+}
+
+func TestExecutionClient_Timeout(t *testing.T) {
+	t.Parallel()
+
+	server := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":"0x0"}`))
+	})
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	n := testClientCounter.Add(1)
+	namespace := "test_timeout_" + strconv.FormatInt(n, 10)
+
+	client := NewExecutionClient(log, NewMetrics(namespace), "node-1", server.URL, nil, 50*time.Millisecond)
+
+	_, err := client.ETHGetBalance(context.Background(), "0x1234567890123456789012345678901234567890", "latest")
+	assert.Error(t, err)
+}
+
+func TestExecutionClient_ConnectionRefused(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, "node-1", "http://127.0.0.1:1")
+
+	_, err := client.ETHGetBalance(context.Background(), "0x1234567890123456789012345678901234567890", "latest")
+	assert.Error(t, err)
+}

--- a/pkg/exporter/api/metrics.go
+++ b/pkg/exporter/api/metrics.go
@@ -18,18 +18,18 @@ func NewMetrics(namespace string) Metrics {
 			Namespace: namespace,
 			Name:      "request_count",
 			Help:      "Number of requests",
-		}, []string{"method", "path", "api_method"}),
+		}, []string{"method", "path", "api_method", "execution"}),
 		responses: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: namespace,
 			Name:      "response_count",
 			Help:      "Number of responses",
-		}, []string{"method", "path", "api_method", "code"}),
+		}, []string{"method", "path", "api_method", "code", "execution"}),
 		requestDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Name:      "request_duration_seconds",
 			Help:      "Request duration (in seconds.)",
 			Buckets:   []float64{0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
-		}, []string{"method", "path", "api_method", "code"}),
+		}, []string{"method", "path", "api_method", "code", "execution"}),
 	}
 
 	prometheus.MustRegister(m.requests)
@@ -39,11 +39,11 @@ func NewMetrics(namespace string) Metrics {
 	return m
 }
 
-func (m Metrics) ObserveRequest(method, path, apiMethod string) {
-	m.requests.WithLabelValues(method, path, apiMethod).Inc()
+func (m Metrics) ObserveRequest(method, path, apiMethod, execution string) {
+	m.requests.WithLabelValues(method, path, apiMethod, execution).Inc()
 }
 
-func (m Metrics) ObserveResponse(method, path, apiMethod, code string, duration time.Duration) {
-	m.responses.WithLabelValues(method, path, apiMethod, code).Inc()
-	m.requestDuration.WithLabelValues(method, path, apiMethod, code).Observe(duration.Seconds())
+func (m Metrics) ObserveResponse(method, path, apiMethod, code, execution string, duration time.Duration) {
+	m.responses.WithLabelValues(method, path, apiMethod, code, execution).Inc()
+	m.requestDuration.WithLabelValues(method, path, apiMethod, code, execution).Observe(duration.Seconds())
 }

--- a/pkg/exporter/config.go
+++ b/pkg/exporter/config.go
@@ -1,6 +1,7 @@
 package exporter
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -10,12 +11,13 @@ import (
 // Config holds the configuration for the ethereum sync status tool.
 type Config struct {
 	GlobalConfig GlobalConfig `yaml:"global"`
-	// Execution is the execution node to use.
-	Execution ExecutionNode `yaml:"execution"`
+	// Execution is the list of execution nodes to query.
+	Execution []*ExecutionNode `yaml:"execution"`
 	// Addresses is the list of addresses to monitor.
 	Addresses Addresses `yaml:"addresses"`
 }
 
+// GlobalConfig holds global configuration settings.
 type GlobalConfig struct {
 	LoggingLevel  string            `yaml:"logging" default:"warn"`
 	MetricsAddr   string            `yaml:"metricsAddr" default:":9090"`
@@ -26,11 +28,13 @@ type GlobalConfig struct {
 
 // ExecutionNode represents a single ethereum execution client.
 type ExecutionNode struct {
+	Name    string            `yaml:"name"`
 	URL     string            `yaml:"url" default:"http://localhost:8545"`
 	Headers map[string]string `yaml:"headers"`
 	Timeout time.Duration     `yaml:"timeout" default:"10s"`
 }
 
+// Addresses holds all address types to monitor.
 type Addresses struct {
 	Account           []*jobs.AddressAccount           `yaml:"account"`
 	ERC20             []*jobs.AddressERC20             `yaml:"erc20"`
@@ -42,86 +46,63 @@ type Addresses struct {
 	ERC4337           []*jobs.AddressERC4337           `yaml:"erc4337"`
 }
 
+// named is implemented by address types that have a Name field.
+type named interface {
+	GetName() string
+}
+
+// checkDuplicateNames validates that no two entries in a slice share the same name.
+func checkDuplicateNames[T named](items []T, typeName string) error {
+	seen := make(map[string]struct{}, len(items))
+
+	for _, item := range items {
+		name := item.GetName()
+		if _, ok := seen[name]; ok {
+			return fmt.Errorf("duplicate %s address with the same name: %s", typeName, name)
+		}
+
+		seen[name] = struct{}{}
+	}
+
+	return nil
+}
+
 func (c *Config) Validate() error {
-	// Check that all account addresses have different names
-	duplicates := make(map[string]struct{})
-	for _, u := range c.Addresses.Account {
-		// Check that all addresses have different names
-		if _, ok := duplicates[u.Name]; ok {
-			return fmt.Errorf("there's a duplicate account addresses with the same name: %s", u.Name)
-		}
-
-		duplicates[u.Name] = struct{}{}
+	if len(c.Execution) == 0 {
+		return errors.New("at least one execution node must be configured")
 	}
 
-	duplicates = make(map[string]struct{})
-	for _, u := range c.Addresses.ERC20 {
-		// Check that all addresses have different names
-		if _, ok := duplicates[u.Name]; ok {
-			return fmt.Errorf("there's a duplicate erc20 addresses with the same name: %s", u.Name)
+	execNames := make(map[string]struct{}, len(c.Execution))
+
+	for i, node := range c.Execution {
+		if node.Name == "" {
+			return fmt.Errorf("execution node at index %d must have a name", i)
 		}
 
-		duplicates[u.Name] = struct{}{}
+		if _, ok := execNames[node.Name]; ok {
+			return fmt.Errorf("duplicate execution node with the same name: %s", node.Name)
+		}
+
+		execNames[node.Name] = struct{}{}
 	}
 
-	duplicates = make(map[string]struct{})
-	for _, u := range c.Addresses.ERC721 {
-		// Check that all addresses have different names
-		if _, ok := duplicates[u.Name]; ok {
-			return fmt.Errorf("there's a duplicate erc721 addresses with the same name: %s", u.Name)
-		}
-
-		duplicates[u.Name] = struct{}{}
+	checks := []struct {
+		err error
+	}{
+		{checkDuplicateNames(c.Addresses.Account, "account")},
+		{checkDuplicateNames(c.Addresses.ERC20, "erc20")},
+		{checkDuplicateNames(c.Addresses.ERC721, "erc721")},
+		{checkDuplicateNames(c.Addresses.ERC1155, "erc1155")},
+		{checkDuplicateNames(c.Addresses.ERC4626, "erc4626")},
+		{checkDuplicateNames(c.Addresses.UniswapPair, "uniswap pair")},
+		{checkDuplicateNames(c.Addresses.ChainlinkDataFeed, "chainlink data feed")},
+		{checkDuplicateNames(c.Addresses.ERC4337, "erc4337")},
 	}
 
-	duplicates = make(map[string]struct{})
-	for _, u := range c.Addresses.ERC1155 {
-		// Check that all addresses have different names
-		if _, ok := duplicates[u.Name]; ok {
-			return fmt.Errorf("there's a duplicate erc1155 addresses with the same name: %s", u.Name)
+	for _, check := range checks {
+		if check.err != nil {
+			return check.err
 		}
-
-		duplicates[u.Name] = struct{}{}
-	}
-
-	duplicates = make(map[string]struct{})
-	for _, u := range c.Addresses.UniswapPair {
-		// Check that all addresses have different names
-		if _, ok := duplicates[u.Name]; ok {
-			return fmt.Errorf("there's a duplicate uniswap pair addresses with the same name: %s", u.Name)
-		}
-
-		duplicates[u.Name] = struct{}{}
-	}
-
-	duplicates = make(map[string]struct{})
-	for _, u := range c.Addresses.ERC4626 {
-		// Check that all addresses have different names
-		if _, ok := duplicates[u.Name]; ok {
-			return fmt.Errorf("there's a duplicate erc4626 addresses with the same name: %s", u.Name)
-		}
-
-		duplicates[u.Name] = struct{}{}
-	}
-
-	duplicates = make(map[string]struct{})
-	for _, u := range c.Addresses.ChainlinkDataFeed {
-		// Check that all addresses have different names
-		if _, ok := duplicates[u.Name]; ok {
-			return fmt.Errorf("there's a duplicate chainlink data feed addresses with the same name: %s", u.Name)
-		}
-
-		duplicates[u.Name] = struct{}{}
-	}
-
-	duplicates = make(map[string]struct{})
-	for _, u := range c.Addresses.ERC4337 {
-		// Check that all addresses have different names
-		if _, ok := duplicates[u.Name]; ok {
-			return fmt.Errorf("there's a duplicate erc4337 addresses with the same name: %s", u.Name)
-		}
-
-		duplicates[u.Name] = struct{}{}
 	}
 
 	return nil

--- a/pkg/exporter/config_test.go
+++ b/pkg/exporter/config_test.go
@@ -1,0 +1,172 @@
+package exporter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter/jobs"
+)
+
+func TestConfig_Validate_ExecutionNodes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		execution []*ExecutionNode
+		wantErr   string
+	}{
+		{
+			name:      "no execution nodes",
+			execution: nil,
+			wantErr:   "at least one execution node must be configured",
+		},
+		{
+			name:      "empty execution list",
+			execution: []*ExecutionNode{},
+			wantErr:   "at least one execution node must be configured",
+		},
+		{
+			name: "missing name",
+			execution: []*ExecutionNode{
+				{Name: "", URL: "http://localhost:8545"},
+			},
+			wantErr: "execution node at index 0 must have a name",
+		},
+		{
+			name: "duplicate names",
+			execution: []*ExecutionNode{
+				{Name: "node-1", URL: "http://localhost:8545"},
+				{Name: "node-1", URL: "http://localhost:8546"},
+			},
+			wantErr: "duplicate execution node with the same name: node-1",
+		},
+		{
+			name: "valid single node",
+			execution: []*ExecutionNode{
+				{Name: "geth-1", URL: "http://localhost:8545", Timeout: 10 * time.Second},
+			},
+		},
+		{
+			name: "valid multiple nodes",
+			execution: []*ExecutionNode{
+				{Name: "geth-1", URL: "http://localhost:8545"},
+				{Name: "nethermind-1", URL: "http://localhost:8546"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &Config{
+				Execution: tt.execution,
+			}
+
+			err := cfg.Validate()
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestConfig_Validate_DuplicateAddressNames(t *testing.T) {
+	t.Parallel()
+
+	validExecution := []*ExecutionNode{
+		{Name: "node-1", URL: "http://localhost:8545"},
+	}
+
+	tests := []struct {
+		name      string
+		addresses Addresses
+		wantErr   string
+	}{
+		{
+			name:      "empty addresses passes",
+			addresses: Addresses{},
+		},
+		{
+			name: "duplicate account names",
+			addresses: Addresses{
+				Account: []*jobs.AddressAccount{
+					{Name: "dup", Address: "0x1111111111111111111111111111111111111111"},
+					{Name: "dup", Address: "0x2222222222222222222222222222222222222222"},
+				},
+			},
+			wantErr: "duplicate account address with the same name: dup",
+		},
+		{
+			name: "duplicate erc20 names",
+			addresses: Addresses{
+				ERC20: []*jobs.AddressERC20{
+					{Name: "token", Address: "0x1111111111111111111111111111111111111111", Contract: "0xaaaa"},
+					{Name: "token", Address: "0x2222222222222222222222222222222222222222", Contract: "0xbbbb"},
+				},
+			},
+			wantErr: "duplicate erc20 address with the same name: token",
+		},
+		{
+			name: "duplicate erc4337 names",
+			addresses: Addresses{
+				ERC4337: []*jobs.AddressERC4337{
+					{Name: "paymaster", Address: "0x1111111111111111111111111111111111111111", Contract: "0xaaaa"},
+					{Name: "paymaster", Address: "0x2222222222222222222222222222222222222222", Contract: "0xbbbb"},
+				},
+			},
+			wantErr: "duplicate erc4337 address with the same name: paymaster",
+		},
+		{
+			name: "same name across different types is OK",
+			addresses: Addresses{
+				Account: []*jobs.AddressAccount{
+					{Name: "shared-name", Address: "0x1111111111111111111111111111111111111111"},
+				},
+				ERC20: []*jobs.AddressERC20{
+					{Name: "shared-name", Address: "0x2222222222222222222222222222222222222222", Contract: "0xaaaa"},
+				},
+			},
+		},
+		{
+			name: "unique names within each type passes",
+			addresses: Addresses{
+				Account: []*jobs.AddressAccount{
+					{Name: "account-1", Address: "0x1111111111111111111111111111111111111111"},
+					{Name: "account-2", Address: "0x2222222222222222222222222222222222222222"},
+				},
+				ERC20: []*jobs.AddressERC20{
+					{Name: "token-1", Address: "0x3333333333333333333333333333333333333333", Contract: "0xaaaa"},
+					{Name: "token-2", Address: "0x4444444444444444444444444444444444444444", Contract: "0xbbbb"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &Config{
+				Execution: validExecution,
+				Addresses: tt.addresses,
+			}
+
+			err := cfg.Validate()
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -6,9 +6,10 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter/api"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
+
+	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter/api"
 )
 
 // Exporter defines the Ethereum Metrics Exporter interface.
@@ -34,7 +35,7 @@ type exporter struct {
 	log logrus.FieldLogger
 	Cfg *Config
 
-	execution api.ExecutionClient
+	clients []api.ExecutionClient
 	// Metrics
 	metrics Metrics
 }
@@ -42,13 +43,38 @@ type exporter struct {
 func (e *exporter) Start(ctx context.Context) error {
 	e.log.Info("Initializing...")
 
-	e.execution = api.NewExecutionClient(e.log, e.Cfg.GlobalConfig.Namespace, e.Cfg.Execution.URL, e.Cfg.Execution.Headers, e.Cfg.Execution.Timeout)
+	e.clients = make([]api.ExecutionClient, 0, len(e.Cfg.Execution))
 
-	e.metrics = NewMetrics(e.execution, e.log, e.Cfg.GlobalConfig.CheckInterval, e.Cfg.GlobalConfig.Namespace, e.Cfg.GlobalConfig.Labels, &e.Cfg.Addresses)
+	httpMetrics := api.NewMetrics(e.Cfg.GlobalConfig.Namespace + "_http")
 
-	e.log.
-		WithField("execution_url", e.Cfg.Execution.URL).
-		Info(fmt.Sprintf("Starting metrics server on %v", e.Cfg.GlobalConfig.MetricsAddr))
+	for _, node := range e.Cfg.Execution {
+		client := api.NewExecutionClient(
+			e.log,
+			httpMetrics,
+			node.Name,
+			node.URL,
+			node.Headers,
+			node.Timeout,
+		)
+
+		e.clients = append(e.clients, client)
+
+		e.log.WithFields(logrus.Fields{
+			"name": node.Name,
+			"url":  node.URL,
+		}).Info("Configured execution node")
+	}
+
+	e.metrics = NewMetrics(
+		e.clients,
+		e.log,
+		e.Cfg.GlobalConfig.CheckInterval,
+		e.Cfg.GlobalConfig.Namespace,
+		e.Cfg.GlobalConfig.Labels,
+		&e.Cfg.Addresses,
+	)
+
+	e.log.Info(fmt.Sprintf("Starting metrics server on %v", e.Cfg.GlobalConfig.MetricsAddr))
 
 	http.Handle("/metrics", promhttp.Handler())
 

--- a/pkg/exporter/jobs/account.go
+++ b/pkg/exporter/jobs/account.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"time"
 
-	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter/api"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+
+	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter/api"
 )
 
-// Eth exposes metrics for account addresses.
+// Account exposes metrics for account addresses.
 type Account struct {
-	client         api.ExecutionClient
+	clients        []api.ExecutionClient
 	log            logrus.FieldLogger
 	AccountBalance prometheus.GaugeVec
 	AccountError   prometheus.CounterVec
@@ -26,6 +27,9 @@ type AddressAccount struct {
 	Labels  map[string]string `yaml:"labels"`
 }
 
+// GetName returns the configured name of this address.
+func (a *AddressAccount) GetName() string { return a.Name }
+
 const (
 	NameAccount = "account"
 )
@@ -35,12 +39,13 @@ func (n *Account) Name() string {
 }
 
 // NewAccount returns a new Account instance.
-func NewAccount(client api.ExecutionClient, log logrus.FieldLogger, checkInterval time.Duration, namespace string, constLabels map[string]string, addresses []*AddressAccount) Account {
+func NewAccount(clients []api.ExecutionClient, log logrus.FieldLogger, checkInterval time.Duration, namespace string, constLabels map[string]string, addresses []*AddressAccount) Account {
 	namespace += "_" + NameAccount
 
-	labelsMap := map[string]int{}
+	labelsMap := make(map[string]int, 3)
 	labelsMap[LabelName] = 0
 	labelsMap[LabelAddress] = 1
+	labelsMap[LabelExecution] = 2
 
 	for address := range addresses {
 		for label := range addresses[address].Labels {
@@ -56,7 +61,7 @@ func NewAccount(client api.ExecutionClient, log logrus.FieldLogger, checkInterva
 	}
 
 	instance := Account{
-		client:        client,
+		clients:       clients,
 		log:           log.WithField("module", NameAccount),
 		addresses:     addresses,
 		checkInterval: checkInterval,
@@ -101,17 +106,21 @@ func (n *Account) Start(ctx context.Context) {
 	}
 }
 
-//nolint:unparam // context will be used in the future
 func (n *Account) tick(ctx context.Context) {
-	for _, address := range n.addresses {
-		err := n.getBalance(address)
-		if err != nil {
-			n.log.WithError(err).WithField("address", address).Error("Failed to get Account balance")
+	for _, client := range n.clients {
+		for _, address := range n.addresses {
+			err := n.getBalance(ctx, client, address)
+			if err != nil {
+				n.log.WithError(err).WithFields(logrus.Fields{
+					"address":   address,
+					"execution": client.Name(),
+				}).Error("Failed to get Account balance")
+			}
 		}
 	}
 }
 
-func (n *Account) getLabelValues(address *AddressAccount) []string {
+func (n *Account) getLabelValues(address *AddressAccount, executionName string) []string {
 	values := make([]string, len(n.labelsMap))
 
 	for label, index := range n.labelsMap {
@@ -123,6 +132,8 @@ func (n *Account) getLabelValues(address *AddressAccount) []string {
 				values[index] = address.Name
 			case LabelAddress:
 				values[index] = address.Address
+			case LabelExecution:
+				values[index] = executionName
 			default:
 				values[index] = LabelDefaultValue
 			}
@@ -132,22 +143,22 @@ func (n *Account) getLabelValues(address *AddressAccount) []string {
 	return values
 }
 
-func (n *Account) getBalance(address *AddressAccount) error {
+func (n *Account) getBalance(ctx context.Context, client api.ExecutionClient, address *AddressAccount) error {
 	var err error
 
 	defer func() {
 		if err != nil {
-			n.AccountError.WithLabelValues(n.getLabelValues(address)...).Inc()
+			n.AccountError.WithLabelValues(n.getLabelValues(address, client.Name())...).Inc()
 		}
 	}()
 
-	balance, err := n.client.ETHGetBalance(address.Address, "latest")
+	balance, err := client.ETHGetBalance(ctx, address.Address, "latest")
 	if err != nil {
 		return err
 	}
 
 	balanceFloat64 := hexStringToFloat64(balance)
-	n.AccountBalance.WithLabelValues(n.getLabelValues(address)...).Set(balanceFloat64)
+	n.AccountBalance.WithLabelValues(n.getLabelValues(address, client.Name())...).Set(balanceFloat64)
 
 	return nil
 }

--- a/pkg/exporter/jobs/account_test.go
+++ b/pkg/exporter/jobs/account_test.go
@@ -2,6 +2,7 @@ package jobs
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -62,10 +63,10 @@ func TestAccount_getBalance(t *testing.T) {
 			log := logrus.New()
 			log.SetLevel(logrus.ErrorLevel)
 
-			namespace := string(rune('a' + i))
+			namespace := "account_test_" + strconv.Itoa(i)
 
 			account := NewAccount(
-				mockClient,
+				mockClients(mockClient),
 				log,
 				15*time.Second,
 				namespace,
@@ -73,7 +74,7 @@ func TestAccount_getBalance(t *testing.T) {
 				[]*AddressAccount{tt.address},
 			)
 
-			err := account.getBalance(tt.address)
+			err := account.getBalance(context.Background(), mockClient, tt.address)
 
 			if (err != nil) != tt.wantError {
 				t.Errorf("getBalance() error = %v, wantError %v", err, tt.wantError)
@@ -104,7 +105,7 @@ func TestAccount_tick(t *testing.T) {
 	}
 
 	account := NewAccount(
-		mockClient,
+		mockClients(mockClient),
 		log,
 		15*time.Second,
 		"test_account_tick",
@@ -116,7 +117,7 @@ func TestAccount_tick(t *testing.T) {
 	account.tick(ctx)
 
 	// ETHGetBalance calls are tracked differently than ETHCall
-	// The mock should have been called for each address
+	// The mock should have been called for each address (1 client * 2 addresses)
 	if mockClient.ethGetBalanceCalls != len(addresses) {
 		t.Errorf("Expected %d ETHGetBalance calls, got %d", len(addresses), mockClient.ethGetBalanceCalls)
 	}
@@ -138,7 +139,7 @@ func TestAccount_getLabelValues(t *testing.T) {
 	}
 
 	account := NewAccount(
-		&mockExecutionClient{},
+		mockClients(&mockExecutionClient{}),
 		log,
 		15*time.Second,
 		"test_account_labels",
@@ -146,7 +147,7 @@ func TestAccount_getLabelValues(t *testing.T) {
 		addresses,
 	)
 
-	labels := account.getLabelValues(addresses[0])
+	labels := account.getLabelValues(addresses[0], "mock-node")
 
 	if len(labels) != len(account.labelsMap) {
 		t.Errorf("Expected %d label values, got %d", len(account.labelsMap), len(labels))

--- a/pkg/exporter/jobs/chainlink_data_feed.go
+++ b/pkg/exporter/jobs/chainlink_data_feed.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"time"
 
-	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter/api"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+
+	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter/api"
 )
 
 // ChainlinkDataFeed exposes metrics for ethereum chainlink data feed contract.
 type ChainlinkDataFeed struct {
-	client                   api.ExecutionClient
+	clients                  []api.ExecutionClient
 	log                      logrus.FieldLogger
 	ChainlinkDataFeedBalance prometheus.GaugeVec
 	ChainlinkDataFeedError   prometheus.CounterVec
@@ -28,6 +29,9 @@ type AddressChainlinkDataFeed struct {
 	Labels   map[string]string `yaml:"labels"`
 }
 
+// GetName returns the configured name of this address.
+func (a *AddressChainlinkDataFeed) GetName() string { return a.Name }
+
 const (
 	NameChainlinkDataFeed = "chainlink_data_feed"
 )
@@ -37,14 +41,15 @@ func (n *ChainlinkDataFeed) Name() string {
 }
 
 // NewChainlinkDataFeed returns a new ChainlinkDataFeed instance.
-func NewChainlinkDataFeed(client api.ExecutionClient, log logrus.FieldLogger, checkInterval time.Duration, namespace string, constLabels map[string]string, addresses []*AddressChainlinkDataFeed) ChainlinkDataFeed {
+func NewChainlinkDataFeed(clients []api.ExecutionClient, log logrus.FieldLogger, checkInterval time.Duration, namespace string, constLabels map[string]string, addresses []*AddressChainlinkDataFeed) ChainlinkDataFeed {
 	namespace += "_" + NameChainlinkDataFeed
 
 	labelsMap := map[string]int{
-		LabelName:     0,
-		LabelContract: 1,
-		LabelFrom:     2,
-		LabelTo:       3,
+		LabelName:      0,
+		LabelContract:  1,
+		LabelFrom:      2,
+		LabelTo:        3,
+		LabelExecution: 4,
 	}
 
 	for address := range addresses {
@@ -61,7 +66,7 @@ func NewChainlinkDataFeed(client api.ExecutionClient, log logrus.FieldLogger, ch
 	}
 
 	instance := ChainlinkDataFeed{
-		client:        client,
+		clients:       clients,
 		log:           log.WithField("module", NameChainlinkDataFeed),
 		addresses:     addresses,
 		checkInterval: checkInterval,
@@ -105,17 +110,21 @@ func (n *ChainlinkDataFeed) Start(ctx context.Context) {
 	}
 }
 
-//nolint:unparam // context will be used in the future
 func (n *ChainlinkDataFeed) tick(ctx context.Context) {
-	for _, address := range n.addresses {
-		err := n.getBalance(address)
-		if err != nil {
-			n.log.WithError(err).WithField("address", address).Error("Failed to get chainlink data feed balance")
+	for _, client := range n.clients {
+		for _, address := range n.addresses {
+			err := n.getBalance(ctx, client, address)
+			if err != nil {
+				n.log.WithError(err).WithFields(logrus.Fields{
+					"address":   address,
+					"execution": client.Name(),
+				}).Error("Failed to get chainlink data feed balance")
+			}
 		}
 	}
 }
 
-func (n *ChainlinkDataFeed) getLabelValues(address *AddressChainlinkDataFeed) []string {
+func (n *ChainlinkDataFeed) getLabelValues(address *AddressChainlinkDataFeed, executionName string) []string {
 	values := make([]string, len(n.labelsMap))
 
 	for label, index := range n.labelsMap {
@@ -131,6 +140,8 @@ func (n *ChainlinkDataFeed) getLabelValues(address *AddressChainlinkDataFeed) []
 				values[index] = address.From
 			case LabelTo:
 				values[index] = address.To
+			case LabelExecution:
+				values[index] = executionName
 			default:
 				values[index] = LabelDefaultValue
 			}
@@ -140,19 +151,19 @@ func (n *ChainlinkDataFeed) getLabelValues(address *AddressChainlinkDataFeed) []
 	return values
 }
 
-func (n *ChainlinkDataFeed) getBalance(address *AddressChainlinkDataFeed) error {
+func (n *ChainlinkDataFeed) getBalance(ctx context.Context, client api.ExecutionClient, address *AddressChainlinkDataFeed) error {
 	var err error
 
 	defer func() {
 		if err != nil {
-			n.ChainlinkDataFeedError.WithLabelValues(n.getLabelValues(address)...).Inc()
+			n.ChainlinkDataFeedError.WithLabelValues(n.getLabelValues(address, client.Name())...).Inc()
 		}
 	}()
 
 	// call latestAnswer() which is 0x50d25bcd
 	latestAnswerData := "0x50d25bcd000000000000000000000000"
 
-	balanceStr, err := n.client.ETHCall(&api.ETHCallTransaction{
+	balanceStr, err := client.ETHCall(ctx, &api.ETHCallTransaction{
 		To:   address.Contract,
 		Data: &latestAnswerData,
 	}, "latest")
@@ -160,7 +171,7 @@ func (n *ChainlinkDataFeed) getBalance(address *AddressChainlinkDataFeed) error 
 		return err
 	}
 
-	n.ChainlinkDataFeedBalance.WithLabelValues(n.getLabelValues(address)...).Set(hexStringToFloat64(balanceStr))
+	n.ChainlinkDataFeedBalance.WithLabelValues(n.getLabelValues(address, client.Name())...).Set(hexStringToFloat64(balanceStr))
 
 	return nil
 }

--- a/pkg/exporter/jobs/chainlink_data_feed_test.go
+++ b/pkg/exporter/jobs/chainlink_data_feed_test.go
@@ -2,6 +2,7 @@ package jobs
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -62,10 +63,10 @@ func TestChainlinkDataFeed_getBalance(t *testing.T) {
 			log := logrus.New()
 			log.SetLevel(logrus.ErrorLevel)
 
-			namespace := "chainlink_" + string(rune('a'+i))
+			namespace := "chainlink_" + strconv.Itoa(i)
 
 			chainlink := NewChainlinkDataFeed(
-				mockClient,
+				mockClients(mockClient),
 				log,
 				15*time.Second,
 				namespace,
@@ -73,7 +74,7 @@ func TestChainlinkDataFeed_getBalance(t *testing.T) {
 				[]*AddressChainlinkDataFeed{tt.address},
 			)
 
-			err := chainlink.getBalance(tt.address)
+			err := chainlink.getBalance(context.Background(), mockClient, tt.address)
 
 			if (err != nil) != tt.wantError {
 				t.Errorf("getBalance() error = %v, wantError %v", err, tt.wantError)
@@ -118,7 +119,7 @@ func TestChainlinkDataFeed_tick(t *testing.T) {
 	}
 
 	chainlink := NewChainlinkDataFeed(
-		mockClient,
+		mockClients(mockClient),
 		log,
 		15*time.Second,
 		"test_chainlink_tick",
@@ -129,7 +130,7 @@ func TestChainlinkDataFeed_tick(t *testing.T) {
 	ctx := context.Background()
 	chainlink.tick(ctx)
 
-	// Each address requires 1 call (latestAnswer)
+	// Each address requires 1 call (latestAnswer), 1 client * 2 addresses
 	expectedCalls := len(addresses)
 	if len(mockClient.callLog) != expectedCalls {
 		t.Errorf("Expected %d RPC calls, got %d", expectedCalls, len(mockClient.callLog))
@@ -153,7 +154,7 @@ func TestChainlinkDataFeed_getLabelValues(t *testing.T) {
 	}
 
 	chainlink := NewChainlinkDataFeed(
-		&mockExecutionClient{},
+		mockClients(&mockExecutionClient{}),
 		log,
 		15*time.Second,
 		"test_chainlink_labels",
@@ -161,7 +162,7 @@ func TestChainlinkDataFeed_getLabelValues(t *testing.T) {
 		addresses,
 	)
 
-	labels := chainlink.getLabelValues(addresses[0])
+	labels := chainlink.getLabelValues(addresses[0], "mock-node")
 
 	if len(labels) != len(chainlink.labelsMap) {
 		t.Errorf("Expected %d label values, got %d", len(chainlink.labelsMap), len(labels))

--- a/pkg/exporter/jobs/erc1155.go
+++ b/pkg/exporter/jobs/erc1155.go
@@ -6,14 +6,15 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter/api"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+
+	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter/api"
 )
 
 // ERC1155 exposes metrics for ethereum ERC115 contract by address and token id.
 type ERC1155 struct {
-	client         api.ExecutionClient
+	clients        []api.ExecutionClient
 	log            logrus.FieldLogger
 	ERC1155Balance prometheus.GaugeVec
 	ERC1155Error   prometheus.CounterVec
@@ -30,6 +31,9 @@ type AddressERC1155 struct {
 	Labels   map[string]string `yaml:"labels"`
 }
 
+// GetName returns the configured name of this address.
+func (a *AddressERC1155) GetName() string { return a.Name }
+
 const (
 	NameERC1155 = "erc1155"
 )
@@ -39,14 +43,15 @@ func (n *ERC1155) Name() string {
 }
 
 // NewERC1155 returns a new ERC1155 instance.
-func NewERC1155(client api.ExecutionClient, log logrus.FieldLogger, checkInterval time.Duration, namespace string, constLabels map[string]string, addresses []*AddressERC1155) ERC1155 {
+func NewERC1155(clients []api.ExecutionClient, log logrus.FieldLogger, checkInterval time.Duration, namespace string, constLabels map[string]string, addresses []*AddressERC1155) ERC1155 {
 	namespace += "_" + NameERC1155
 
 	labelsMap := map[string]int{
-		LabelName:     0,
-		LabelAddress:  1,
-		LabelContract: 2,
-		LabelTokenID:  3,
+		LabelName:      0,
+		LabelAddress:   1,
+		LabelContract:  2,
+		LabelTokenID:   3,
+		LabelExecution: 4,
 	}
 
 	for address := range addresses {
@@ -63,7 +68,7 @@ func NewERC1155(client api.ExecutionClient, log logrus.FieldLogger, checkInterva
 	}
 
 	instance := ERC1155{
-		client:        client,
+		clients:       clients,
 		log:           log.WithField("module", NameERC1155),
 		addresses:     addresses,
 		checkInterval: checkInterval,
@@ -107,17 +112,21 @@ func (n *ERC1155) Start(ctx context.Context) {
 	}
 }
 
-//nolint:unparam // context will be used in the future
 func (n *ERC1155) tick(ctx context.Context) {
-	for _, address := range n.addresses {
-		err := n.getBalance(address)
-		if err != nil {
-			n.log.WithError(err).WithField("address", address).Error("Failed to get erc1155 contract balanceOf address")
+	for _, client := range n.clients {
+		for _, address := range n.addresses {
+			err := n.getBalance(ctx, client, address)
+			if err != nil {
+				n.log.WithError(err).WithFields(logrus.Fields{
+					"address":   address,
+					"execution": client.Name(),
+				}).Error("Failed to get erc1155 contract balanceOf address")
+			}
 		}
 	}
 }
 
-func (n *ERC1155) getLabelValues(address *AddressERC1155) []string {
+func (n *ERC1155) getLabelValues(address *AddressERC1155, executionName string) []string {
 	values := make([]string, len(n.labelsMap))
 
 	for label, index := range n.labelsMap {
@@ -133,6 +142,8 @@ func (n *ERC1155) getLabelValues(address *AddressERC1155) []string {
 				values[index] = address.Contract
 			case LabelTokenID:
 				values[index] = address.TokenID.String()
+			case LabelExecution:
+				values[index] = executionName
 			default:
 				values[index] = LabelDefaultValue
 			}
@@ -142,19 +153,19 @@ func (n *ERC1155) getLabelValues(address *AddressERC1155) []string {
 	return values
 }
 
-func (n *ERC1155) getBalance(address *AddressERC1155) error {
+func (n *ERC1155) getBalance(ctx context.Context, client api.ExecutionClient, address *AddressERC1155) error {
 	var err error
 
 	defer func() {
 		if err != nil {
-			n.ERC1155Error.WithLabelValues(n.getLabelValues(address)...).Inc()
+			n.ERC1155Error.WithLabelValues(n.getLabelValues(address, client.Name())...).Inc()
 		}
 	}()
 
 	// call balanceOf(address,uint256) which is 0x00fdd58e
 	balanceOfData := "0x00fdd58e000000000000000000000000" + address.Address[2:] + fmt.Sprintf("%064x", &address.TokenID)
 
-	balanceStr, err := n.client.ETHCall(&api.ETHCallTransaction{
+	balanceStr, err := client.ETHCall(ctx, &api.ETHCallTransaction{
 		To:   address.Contract,
 		Data: &balanceOfData,
 	}, "latest")
@@ -162,7 +173,7 @@ func (n *ERC1155) getBalance(address *AddressERC1155) error {
 		return err
 	}
 
-	n.ERC1155Balance.WithLabelValues(n.getLabelValues(address)...).Set(hexStringToFloat64(balanceStr))
+	n.ERC1155Balance.WithLabelValues(n.getLabelValues(address, client.Name())...).Set(hexStringToFloat64(balanceStr))
 
 	return nil
 }

--- a/pkg/exporter/jobs/erc1155_test.go
+++ b/pkg/exporter/jobs/erc1155_test.go
@@ -3,6 +3,7 @@ package jobs
 import (
 	"context"
 	"math/big"
+	"strconv"
 	"testing"
 	"time"
 
@@ -65,10 +66,10 @@ func TestERC1155_getBalance(t *testing.T) {
 			log := logrus.New()
 			log.SetLevel(logrus.ErrorLevel)
 
-			namespace := "erc1155_" + string(rune('a'+i))
+			namespace := "erc1155_" + strconv.Itoa(i)
 
 			erc1155 := NewERC1155(
-				mockClient,
+				mockClients(mockClient),
 				log,
 				15*time.Second,
 				namespace,
@@ -76,7 +77,7 @@ func TestERC1155_getBalance(t *testing.T) {
 				[]*AddressERC1155{tt.address},
 			)
 
-			err := erc1155.getBalance(tt.address)
+			err := erc1155.getBalance(context.Background(), mockClient, tt.address)
 
 			if (err != nil) != tt.wantError {
 				t.Errorf("getBalance() error = %v, wantError %v", err, tt.wantError)
@@ -123,7 +124,7 @@ func TestERC1155_tick(t *testing.T) {
 	}
 
 	erc1155 := NewERC1155(
-		mockClient,
+		mockClients(mockClient),
 		log,
 		15*time.Second,
 		"test_erc1155_tick",
@@ -134,7 +135,7 @@ func TestERC1155_tick(t *testing.T) {
 	ctx := context.Background()
 	erc1155.tick(ctx)
 
-	// Each address requires 1 call (balanceOf)
+	// Each address requires 1 call (balanceOf), 1 client * 2 addresses
 	expectedCalls := len(addresses)
 	if len(mockClient.callLog) != expectedCalls {
 		t.Errorf("Expected %d RPC calls, got %d", expectedCalls, len(mockClient.callLog))
@@ -160,7 +161,7 @@ func TestERC1155_getLabelValues(t *testing.T) {
 	}
 
 	erc1155 := NewERC1155(
-		&mockExecutionClient{},
+		mockClients(&mockExecutionClient{}),
 		log,
 		15*time.Second,
 		"test_erc1155_labels",
@@ -168,7 +169,7 @@ func TestERC1155_getLabelValues(t *testing.T) {
 		addresses,
 	)
 
-	labels := erc1155.getLabelValues(addresses[0])
+	labels := erc1155.getLabelValues(addresses[0], "mock-node")
 
 	if len(labels) != len(erc1155.labelsMap) {
 		t.Errorf("Expected %d label values, got %d", len(erc1155.labelsMap), len(labels))

--- a/pkg/exporter/jobs/erc20.go
+++ b/pkg/exporter/jobs/erc20.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"time"
 
-	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter/api"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+
+	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter/api"
 )
 
 // ERC20 exposes metrics for ethereum ERC20 contract by address.
 type ERC20 struct {
-	client        api.ExecutionClient
+	clients       []api.ExecutionClient
 	log           logrus.FieldLogger
 	ERC20Balance  prometheus.GaugeVec
 	ERC20Error    prometheus.CounterVec
@@ -27,6 +28,9 @@ type AddressERC20 struct {
 	Labels   map[string]string `yaml:"labels"`
 }
 
+// GetName returns the configured name of this address.
+func (a *AddressERC20) GetName() string { return a.Name }
+
 const (
 	NameERC20 = "erc20"
 )
@@ -36,14 +40,15 @@ func (n *ERC20) Name() string {
 }
 
 // NewERC20 returns a new ERC20 instance.
-func NewERC20(client api.ExecutionClient, log logrus.FieldLogger, checkInterval time.Duration, namespace string, constLabels map[string]string, addresses []*AddressERC20) ERC20 {
+func NewERC20(clients []api.ExecutionClient, log logrus.FieldLogger, checkInterval time.Duration, namespace string, constLabels map[string]string, addresses []*AddressERC20) ERC20 {
 	namespace += "_" + NameERC20
 
 	labelsMap := map[string]int{
-		LabelName:     0,
-		LabelAddress:  1,
-		LabelContract: 2,
-		LabelSymbol:   3,
+		LabelName:      0,
+		LabelAddress:   1,
+		LabelContract:  2,
+		LabelSymbol:    3,
+		LabelExecution: 4,
 	}
 
 	for address := range addresses {
@@ -60,7 +65,7 @@ func NewERC20(client api.ExecutionClient, log logrus.FieldLogger, checkInterval 
 	}
 
 	instance := ERC20{
-		client:        client,
+		clients:       clients,
 		log:           log.WithField("module", NameERC20),
 		addresses:     addresses,
 		checkInterval: checkInterval,
@@ -104,17 +109,21 @@ func (n *ERC20) Start(ctx context.Context) {
 	}
 }
 
-//nolint:unparam // context will be used in the future
 func (n *ERC20) tick(ctx context.Context) {
-	for _, address := range n.addresses {
-		err := n.getBalance(address)
-		if err != nil {
-			n.log.WithError(err).WithField("address", address).Error("Failed to get erc20 contract balanceOf address")
+	for _, client := range n.clients {
+		for _, address := range n.addresses {
+			err := n.getBalance(ctx, client, address)
+			if err != nil {
+				n.log.WithError(err).WithFields(logrus.Fields{
+					"address":   address,
+					"execution": client.Name(),
+				}).Error("Failed to get erc20 contract balanceOf address")
+			}
 		}
 	}
 }
 
-func (n *ERC20) getLabelValues(address *AddressERC20, symbol string) []string {
+func (n *ERC20) getLabelValues(address *AddressERC20, symbol, executionName string) []string {
 	values := make([]string, len(n.labelsMap))
 
 	for label, index := range n.labelsMap {
@@ -130,6 +139,8 @@ func (n *ERC20) getLabelValues(address *AddressERC20, symbol string) []string {
 				values[index] = address.Contract
 			case LabelSymbol:
 				values[index] = symbol
+			case LabelExecution:
+				values[index] = executionName
 			default:
 				values[index] = LabelDefaultValue
 			}
@@ -139,21 +150,21 @@ func (n *ERC20) getLabelValues(address *AddressERC20, symbol string) []string {
 	return values
 }
 
-func (n *ERC20) getBalance(address *AddressERC20) error {
+func (n *ERC20) getBalance(ctx context.Context, client api.ExecutionClient, address *AddressERC20) error {
 	var err error
 
 	symbol := ""
 
 	defer func() {
 		if err != nil {
-			n.ERC20Error.WithLabelValues(n.getLabelValues(address, symbol)...).Inc()
+			n.ERC20Error.WithLabelValues(n.getLabelValues(address, symbol, client.Name())...).Inc()
 		}
 	}()
 
 	// call balanceOf(address) which is 0x70a08231
 	balanceOfData := "0x70a08231000000000000000000000000" + address.Address[2:]
 
-	balanceStr, err := n.client.ETHCall(&api.ETHCallTransaction{
+	balanceStr, err := client.ETHCall(ctx, &api.ETHCallTransaction{
 		To:   address.Contract,
 		Data: &balanceOfData,
 	}, "latest")
@@ -164,7 +175,7 @@ func (n *ERC20) getBalance(address *AddressERC20) error {
 	// call symbol() which is 0x95d89b41
 	symbolData := "0x95d89b41000000000000000000000000"
 
-	symbolHex, err := n.client.ETHCall(&api.ETHCallTransaction{
+	symbolHex, err := client.ETHCall(ctx, &api.ETHCallTransaction{
 		To:   address.Contract,
 		Data: &symbolData,
 	}, "latest")
@@ -177,7 +188,7 @@ func (n *ERC20) getBalance(address *AddressERC20) error {
 		return err
 	}
 
-	n.ERC20Balance.WithLabelValues(n.getLabelValues(address, symbol)...).Set(hexStringToFloat64(balanceStr))
+	n.ERC20Balance.WithLabelValues(n.getLabelValues(address, symbol, client.Name())...).Set(hexStringToFloat64(balanceStr))
 
 	return nil
 }

--- a/pkg/exporter/jobs/erc20_test.go
+++ b/pkg/exporter/jobs/erc20_test.go
@@ -2,6 +2,7 @@ package jobs
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -64,10 +65,10 @@ func TestERC20_getBalance(t *testing.T) {
 			log := logrus.New()
 			log.SetLevel(logrus.ErrorLevel)
 
-			namespace := "erc20_" + string(rune('a'+i))
+			namespace := "erc20_" + strconv.Itoa(i)
 
 			erc20 := NewERC20(
-				mockClient,
+				mockClients(mockClient),
 				log,
 				15*time.Second,
 				namespace,
@@ -75,7 +76,7 @@ func TestERC20_getBalance(t *testing.T) {
 				[]*AddressERC20{tt.address},
 			)
 
-			err := erc20.getBalance(tt.address)
+			err := erc20.getBalance(context.Background(), mockClient, tt.address)
 
 			if (err != nil) != tt.wantError {
 				t.Errorf("getBalance() error = %v, wantError %v", err, tt.wantError)
@@ -123,7 +124,7 @@ func TestERC20_tick(t *testing.T) {
 	}
 
 	erc20 := NewERC20(
-		mockClient,
+		mockClients(mockClient),
 		log,
 		15*time.Second,
 		"test_erc20_tick",
@@ -134,7 +135,7 @@ func TestERC20_tick(t *testing.T) {
 	ctx := context.Background()
 	erc20.tick(ctx)
 
-	// Each address requires 2 calls (balanceOf + symbol)
+	// Each address requires 2 calls (balanceOf + symbol), 1 client * 2 addresses
 	expectedCalls := len(addresses) * 2
 	if len(mockClient.callLog) != expectedCalls {
 		t.Errorf("Expected %d RPC calls, got %d", expectedCalls, len(mockClient.callLog))
@@ -157,7 +158,7 @@ func TestERC20_getLabelValues(t *testing.T) {
 	}
 
 	erc20 := NewERC20(
-		&mockExecutionClient{},
+		mockClients(&mockExecutionClient{}),
 		log,
 		15*time.Second,
 		"test_erc20_labels",
@@ -165,7 +166,7 @@ func TestERC20_getLabelValues(t *testing.T) {
 		addresses,
 	)
 
-	labels := erc20.getLabelValues(addresses[0], "USDC")
+	labels := erc20.getLabelValues(addresses[0], "USDC", "mock-node")
 
 	if len(labels) != len(erc20.labelsMap) {
 		t.Errorf("Expected %d label values, got %d", len(erc20.labelsMap), len(labels))

--- a/pkg/exporter/jobs/erc4337.go
+++ b/pkg/exporter/jobs/erc4337.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"time"
 
-	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter/api"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+
+	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter/api"
 )
 
 // ERC4337 exposes metrics for ethereum ERC4337 EntryPoint contract by address.
 type ERC4337 struct {
-	client         api.ExecutionClient
+	clients        []api.ExecutionClient
 	log            logrus.FieldLogger
 	ERC4337Balance prometheus.GaugeVec
 	ERC4337Error   prometheus.CounterVec
@@ -27,6 +28,9 @@ type AddressERC4337 struct {
 	Labels   map[string]string `yaml:"labels"`
 }
 
+// GetName returns the configured name of this address.
+func (a *AddressERC4337) GetName() string { return a.Name }
+
 const (
 	NameERC4337 = "erc4337"
 )
@@ -36,13 +40,14 @@ func (n *ERC4337) Name() string {
 }
 
 // NewERC4337 returns a new ERC4337 instance.
-func NewERC4337(client api.ExecutionClient, log logrus.FieldLogger, checkInterval time.Duration, namespace string, constLabels map[string]string, addresses []*AddressERC4337) ERC4337 {
+func NewERC4337(clients []api.ExecutionClient, log logrus.FieldLogger, checkInterval time.Duration, namespace string, constLabels map[string]string, addresses []*AddressERC4337) ERC4337 {
 	namespace += "_" + NameERC4337
 
 	labelsMap := map[string]int{
-		LabelName:     0,
-		LabelAddress:  1,
-		LabelContract: 2,
+		LabelName:      0,
+		LabelAddress:   1,
+		LabelContract:  2,
+		LabelExecution: 3,
 	}
 
 	for address := range addresses {
@@ -59,7 +64,7 @@ func NewERC4337(client api.ExecutionClient, log logrus.FieldLogger, checkInterva
 	}
 
 	instance := ERC4337{
-		client:        client,
+		clients:       clients,
 		log:           log.WithField("module", NameERC4337),
 		addresses:     addresses,
 		checkInterval: checkInterval,
@@ -103,17 +108,21 @@ func (n *ERC4337) Start(ctx context.Context) {
 	}
 }
 
-//nolint:unparam // context will be used in the future
 func (n *ERC4337) tick(ctx context.Context) {
-	for _, address := range n.addresses {
-		err := n.getBalance(address)
-		if err != nil {
-			n.log.WithError(err).WithField("address", address).Error("Failed to get erc4337 contract balanceOf address")
+	for _, client := range n.clients {
+		for _, address := range n.addresses {
+			err := n.getBalance(ctx, client, address)
+			if err != nil {
+				n.log.WithError(err).WithFields(logrus.Fields{
+					"address":   address,
+					"execution": client.Name(),
+				}).Error("Failed to get erc4337 contract balanceOf address")
+			}
 		}
 	}
 }
 
-func (n *ERC4337) getLabelValues(address *AddressERC4337) []string {
+func (n *ERC4337) getLabelValues(address *AddressERC4337, executionName string) []string {
 	values := make([]string, len(n.labelsMap))
 
 	for label, index := range n.labelsMap {
@@ -127,6 +136,8 @@ func (n *ERC4337) getLabelValues(address *AddressERC4337) []string {
 				values[index] = address.Address
 			case LabelContract:
 				values[index] = address.Contract
+			case LabelExecution:
+				values[index] = executionName
 			default:
 				values[index] = LabelDefaultValue
 			}
@@ -136,12 +147,12 @@ func (n *ERC4337) getLabelValues(address *AddressERC4337) []string {
 	return values
 }
 
-func (n *ERC4337) getBalance(address *AddressERC4337) error {
+func (n *ERC4337) getBalance(ctx context.Context, client api.ExecutionClient, address *AddressERC4337) error {
 	var err error
 
 	defer func() {
 		if err != nil {
-			n.ERC4337Error.WithLabelValues(n.getLabelValues(address)...).Inc()
+			n.ERC4337Error.WithLabelValues(n.getLabelValues(address, client.Name())...).Inc()
 		}
 	}()
 
@@ -149,7 +160,7 @@ func (n *ERC4337) getBalance(address *AddressERC4337) error {
 	// This is the standard ERC20 balanceOf signature, which EntryPoint also uses for deposits
 	balanceOfData := "0x70a08231000000000000000000000000" + address.Address[2:]
 
-	balanceStr, err := n.client.ETHCall(&api.ETHCallTransaction{
+	balanceStr, err := client.ETHCall(ctx, &api.ETHCallTransaction{
 		To:   address.Contract,
 		Data: &balanceOfData,
 	}, "latest")
@@ -157,7 +168,7 @@ func (n *ERC4337) getBalance(address *AddressERC4337) error {
 		return err
 	}
 
-	n.ERC4337Balance.WithLabelValues(n.getLabelValues(address)...).Set(hexStringToFloat64(balanceStr))
+	n.ERC4337Balance.WithLabelValues(n.getLabelValues(address, client.Name())...).Set(hexStringToFloat64(balanceStr))
 
 	return nil
 }

--- a/pkg/exporter/jobs/erc4337_test.go
+++ b/pkg/exporter/jobs/erc4337_test.go
@@ -2,6 +2,7 @@ package jobs
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -48,10 +49,10 @@ func TestERC4337_getBalance(t *testing.T) {
 			log := logrus.New()
 			log.SetLevel(logrus.ErrorLevel)
 
-			namespace := "erc4337_" + string(rune('a'+i))
+			namespace := "erc4337_" + strconv.Itoa(i)
 
 			erc4337 := NewERC4337(
-				mockClient,
+				mockClients(mockClient),
 				log,
 				15*time.Second,
 				namespace,
@@ -59,7 +60,7 @@ func TestERC4337_getBalance(t *testing.T) {
 				[]*AddressERC4337{tt.address},
 			)
 
-			err := erc4337.getBalance(tt.address)
+			err := erc4337.getBalance(context.Background(), mockClient, tt.address)
 
 			if (err != nil) != tt.wantError {
 				t.Errorf("getBalance() error = %v, wantError %v", err, tt.wantError)
@@ -102,7 +103,7 @@ func TestERC4337_tick(t *testing.T) {
 	}
 
 	erc4337 := NewERC4337(
-		mockClient,
+		mockClients(mockClient),
 		log,
 		15*time.Second,
 		"test_erc4337_tick",
@@ -113,7 +114,7 @@ func TestERC4337_tick(t *testing.T) {
 	ctx := context.Background()
 	erc4337.tick(ctx)
 
-	// Each address requires 1 call (balanceOf)
+	// Each address requires 1 call (balanceOf), 1 client * 2 addresses
 	expectedCalls := len(addresses)
 	if len(mockClient.callLog) != expectedCalls {
 		t.Errorf("Expected %d RPC calls, got %d", expectedCalls, len(mockClient.callLog))
@@ -136,7 +137,7 @@ func TestERC4337_getLabelValues(t *testing.T) {
 	}
 
 	erc4337 := NewERC4337(
-		&mockExecutionClient{},
+		mockClients(&mockExecutionClient{}),
 		log,
 		15*time.Second,
 		"test_erc4337_labels",
@@ -144,7 +145,7 @@ func TestERC4337_getLabelValues(t *testing.T) {
 		addresses,
 	)
 
-	labels := erc4337.getLabelValues(addresses[0])
+	labels := erc4337.getLabelValues(addresses[0], "mock-node")
 
 	if len(labels) != len(erc4337.labelsMap) {
 		t.Errorf("Expected %d label values, got %d", len(erc4337.labelsMap), len(labels))

--- a/pkg/exporter/jobs/erc4626.go
+++ b/pkg/exporter/jobs/erc4626.go
@@ -6,14 +6,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter/api"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+
+	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter/api"
 )
 
 // ERC4626 exposes metrics for ethereum ERC4626 vault contracts.
 type ERC4626 struct {
-	client        api.ExecutionClient
+	clients       []api.ExecutionClient
 	log           logrus.FieldLogger
 	ERC4626Assets prometheus.GaugeVec
 	ERC4626Error  prometheus.CounterVec
@@ -29,6 +30,9 @@ type AddressERC4626 struct {
 	Labels   map[string]string `yaml:"labels"`
 }
 
+// GetName returns the configured name of this address.
+func (a *AddressERC4626) GetName() string { return a.Name }
+
 const (
 	NameERC4626 = "erc4626"
 )
@@ -38,14 +42,15 @@ func (n *ERC4626) Name() string {
 }
 
 // NewERC4626 returns a new ERC4626 instance.
-func NewERC4626(client api.ExecutionClient, log logrus.FieldLogger, checkInterval time.Duration, namespace string, constLabels map[string]string, addresses []*AddressERC4626) ERC4626 {
+func NewERC4626(clients []api.ExecutionClient, log logrus.FieldLogger, checkInterval time.Duration, namespace string, constLabels map[string]string, addresses []*AddressERC4626) ERC4626 {
 	namespace += "_" + NameERC4626
 
 	labelsMap := map[string]int{
-		LabelName:     0,
-		LabelAddress:  1,
-		LabelContract: 2,
-		LabelSymbol:   3,
+		LabelName:      0,
+		LabelAddress:   1,
+		LabelContract:  2,
+		LabelSymbol:    3,
+		LabelExecution: 4,
 	}
 
 	for address := range addresses {
@@ -62,7 +67,7 @@ func NewERC4626(client api.ExecutionClient, log logrus.FieldLogger, checkInterva
 	}
 
 	instance := ERC4626{
-		client:        client,
+		clients:       clients,
 		log:           log.WithField("module", NameERC4626),
 		addresses:     addresses,
 		checkInterval: checkInterval,
@@ -106,17 +111,21 @@ func (n *ERC4626) Start(ctx context.Context) {
 	}
 }
 
-//nolint:unparam // context will be used in the future
 func (n *ERC4626) tick(ctx context.Context) {
-	for _, address := range n.addresses {
-		err := n.getAssets(address)
-		if err != nil {
-			n.log.WithError(err).WithField("address", address).Error("Failed to get ERC4626 vault assets")
+	for _, client := range n.clients {
+		for _, address := range n.addresses {
+			err := n.getAssets(ctx, client, address)
+			if err != nil {
+				n.log.WithError(err).WithFields(logrus.Fields{
+					"address":   address,
+					"execution": client.Name(),
+				}).Error("Failed to get ERC4626 vault assets")
+			}
 		}
 	}
 }
 
-func (n *ERC4626) getLabelValues(address *AddressERC4626, symbol string) []string {
+func (n *ERC4626) getLabelValues(address *AddressERC4626, symbol, executionName string) []string {
 	values := make([]string, len(n.labelsMap))
 
 	for label, index := range n.labelsMap {
@@ -132,6 +141,8 @@ func (n *ERC4626) getLabelValues(address *AddressERC4626, symbol string) []strin
 				values[index] = address.Contract
 			case LabelSymbol:
 				values[index] = symbol
+			case LabelExecution:
+				values[index] = executionName
 			default:
 				values[index] = LabelDefaultValue
 			}
@@ -141,14 +152,14 @@ func (n *ERC4626) getLabelValues(address *AddressERC4626, symbol string) []strin
 	return values
 }
 
-func (n *ERC4626) getAssets(address *AddressERC4626) error {
+func (n *ERC4626) getAssets(ctx context.Context, client api.ExecutionClient, address *AddressERC4626) error {
 	var err error
 
 	symbol := ""
 
 	defer func() {
 		if err != nil {
-			n.ERC4626Error.WithLabelValues(n.getLabelValues(address, symbol)...).Inc()
+			n.ERC4626Error.WithLabelValues(n.getLabelValues(address, symbol, client.Name())...).Inc()
 		}
 	}()
 
@@ -156,7 +167,7 @@ func (n *ERC4626) getAssets(address *AddressERC4626) error {
 	// Function selector for balanceOf(address) is 0x70a08231
 	balanceOfData := "0x70a08231000000000000000000000000" + address.Address[2:]
 
-	sharesStr, err := n.client.ETHCall(&api.ETHCallTransaction{
+	sharesStr, err := client.ETHCall(ctx, &api.ETHCallTransaction{
 		To:   address.Contract,
 		Data: &balanceOfData,
 	}, "latest")
@@ -179,7 +190,7 @@ func (n *ERC4626) getAssets(address *AddressERC4626) error {
 	// Function selector for convertToAssets(uint256) is 0x07a2d13a
 	convertToAssetsData := "0x07a2d13a" + shares
 
-	assetsStr, err := n.client.ETHCall(&api.ETHCallTransaction{
+	assetsStr, err := client.ETHCall(ctx, &api.ETHCallTransaction{
 		To:   address.Contract,
 		Data: &convertToAssetsData,
 	}, "latest")
@@ -191,7 +202,7 @@ func (n *ERC4626) getAssets(address *AddressERC4626) error {
 	// Function selector for symbol() is 0x95d89b41
 	symbolData := "0x95d89b41000000000000000000000000"
 
-	symbolHex, err := n.client.ETHCall(&api.ETHCallTransaction{
+	symbolHex, err := client.ETHCall(ctx, &api.ETHCallTransaction{
 		To:   address.Contract,
 		Data: &symbolData,
 	}, "latest")
@@ -204,7 +215,7 @@ func (n *ERC4626) getAssets(address *AddressERC4626) error {
 		return err
 	}
 
-	n.ERC4626Assets.WithLabelValues(n.getLabelValues(address, symbol)...).Set(hexStringToFloat64(assetsStr))
+	n.ERC4626Assets.WithLabelValues(n.getLabelValues(address, symbol, client.Name())...).Set(hexStringToFloat64(assetsStr))
 
 	return nil
 }

--- a/pkg/exporter/jobs/erc4626_test.go
+++ b/pkg/exporter/jobs/erc4626_test.go
@@ -2,15 +2,18 @@ package jobs
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
-	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter/api"
 	"github.com/sirupsen/logrus"
+
+	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter/api"
 )
 
 // mockExecutionClient is a mock implementation of the ExecutionClient interface for testing.
 type mockExecutionClient struct {
+	name                    string
 	balanceOfResponse       string
 	convertToAssetsResponse string
 	symbolResponse          string
@@ -30,7 +33,16 @@ type mockCall struct {
 	data string
 }
 
-func (m *mockExecutionClient) ETHCall(transaction *api.ETHCallTransaction, block string) (string, error) {
+func (m *mockExecutionClient) Name() string {
+	if m.name != "" {
+		return m.name
+	}
+
+	return "mock-node"
+}
+
+//nolint:gocognit // mock dispatches to different responses based on function selector
+func (m *mockExecutionClient) ETHCall(_ context.Context, transaction *api.ETHCallTransaction, block string) (string, error) {
 	m.callLog = append(m.callLog, mockCall{
 		to:   transaction.To,
 		data: *transaction.Data,
@@ -97,7 +109,7 @@ func (m *mockExecutionClient) ETHCall(transaction *api.ETHCallTransaction, block
 	return "0x0", nil
 }
 
-func (m *mockExecutionClient) ETHGetBalance(address string, block string) (string, error) {
+func (m *mockExecutionClient) ETHGetBalance(_ context.Context, address string, block string) (string, error) {
 	m.ethGetBalanceCalls++
 
 	if m.ethGetBalanceError != nil {
@@ -111,6 +123,12 @@ func (m *mockExecutionClient) ETHGetBalance(address string, block string) (strin
 	return "0x0", nil
 }
 
+// mockClients wraps a single mock client in a slice for use with job constructors.
+func mockClients(m *mockExecutionClient) []api.ExecutionClient {
+	return []api.ExecutionClient{m}
+}
+
+//nolint:gocognit,funlen // table-driven test with detailed call verification
 func TestERC4626_getAssets(t *testing.T) {
 	tests := []struct {
 		name                    string
@@ -174,10 +192,10 @@ func TestERC4626_getAssets(t *testing.T) {
 			log.SetLevel(logrus.ErrorLevel)
 
 			// Use unique namespace for each test to avoid Prometheus registration conflicts
-			namespace := string(rune('a' + i))
+			namespace := "erc4626_" + strconv.Itoa(i)
 
 			erc4626 := NewERC4626(
-				mockClient,
+				mockClients(mockClient),
 				log,
 				15*time.Second,
 				namespace,
@@ -185,7 +203,7 @@ func TestERC4626_getAssets(t *testing.T) {
 				[]*AddressERC4626{tt.address},
 			)
 
-			err := erc4626.getAssets(tt.address)
+			err := erc4626.getAssets(context.Background(), mockClient, tt.address)
 
 			if (err != nil) != tt.wantError {
 				t.Errorf("getAssets() error = %v, wantError %v", err, tt.wantError)
@@ -262,7 +280,7 @@ func TestERC4626_tick(t *testing.T) {
 	}
 
 	erc4626 := NewERC4626(
-		mockClient,
+		mockClients(mockClient),
 		log,
 		15*time.Second,
 		"test_tick",
@@ -273,7 +291,7 @@ func TestERC4626_tick(t *testing.T) {
 	ctx := context.Background()
 	erc4626.tick(ctx)
 
-	// Verify that tick called getAssets for each address (2 addresses * 3 calls each = 6 total)
+	// Verify that tick called getAssets for each address (1 client * 2 addresses * 3 calls each = 6 total)
 	expectedCalls := len(addresses) * 3
 	if len(mockClient.callLog) != expectedCalls {
 		t.Errorf("Expected %d RPC calls for %d addresses, got %d", expectedCalls, len(addresses), len(mockClient.callLog))
@@ -297,9 +315,9 @@ func TestERC4626_getLabelValues(t *testing.T) {
 	}
 
 	erc4626 := NewERC4626(
-		&mockExecutionClient{
+		mockClients(&mockExecutionClient{
 			symbolResponse: "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000973555344432d5661756c74000000000000000000000000000000000000000000", // "sUSDC-Vault"
-		},
+		}),
 		log,
 		15*time.Second,
 		"test_labels",
@@ -307,7 +325,7 @@ func TestERC4626_getLabelValues(t *testing.T) {
 		addresses,
 	)
 
-	labels := erc4626.getLabelValues(addresses[0], "sUSDC-Vault")
+	labels := erc4626.getLabelValues(addresses[0], "sUSDC-Vault", "mock-node")
 
 	// Verify label values are populated correctly
 	if len(labels) != len(erc4626.labelsMap) {

--- a/pkg/exporter/jobs/erc721.go
+++ b/pkg/exporter/jobs/erc721.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"time"
 
-	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter/api"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+
+	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter/api"
 )
 
 // ERC721 exposes metrics for ethereum ERC721 contract by address.
 type ERC721 struct {
-	client        api.ExecutionClient
+	clients       []api.ExecutionClient
 	log           logrus.FieldLogger
 	ERC721Balance prometheus.GaugeVec
 	ERC721Error   prometheus.CounterVec
@@ -27,6 +28,9 @@ type AddressERC721 struct {
 	Labels   map[string]string `yaml:"labels"`
 }
 
+// GetName returns the configured name of this address.
+func (a *AddressERC721) GetName() string { return a.Name }
+
 const (
 	NameERC721 = "erc721"
 )
@@ -36,13 +40,14 @@ func (n *ERC721) Name() string {
 }
 
 // NewERC721 returns a new ERC721 instance.
-func NewERC721(client api.ExecutionClient, log logrus.FieldLogger, checkInterval time.Duration, namespace string, constLabels map[string]string, addresses []*AddressERC721) ERC721 {
+func NewERC721(clients []api.ExecutionClient, log logrus.FieldLogger, checkInterval time.Duration, namespace string, constLabels map[string]string, addresses []*AddressERC721) ERC721 {
 	namespace += "_" + NameERC721
 
 	labelsMap := map[string]int{
-		LabelName:     0,
-		LabelAddress:  1,
-		LabelContract: 2,
+		LabelName:      0,
+		LabelAddress:   1,
+		LabelContract:  2,
+		LabelExecution: 3,
 	}
 
 	for address := range addresses {
@@ -59,7 +64,7 @@ func NewERC721(client api.ExecutionClient, log logrus.FieldLogger, checkInterval
 	}
 
 	instance := ERC721{
-		client:        client,
+		clients:       clients,
 		log:           log.WithField("module", NameERC721),
 		addresses:     addresses,
 		checkInterval: checkInterval,
@@ -103,17 +108,21 @@ func (n *ERC721) Start(ctx context.Context) {
 	}
 }
 
-//nolint:unparam // context will be used in the future
 func (n *ERC721) tick(ctx context.Context) {
-	for _, address := range n.addresses {
-		err := n.getBalance(address)
-		if err != nil {
-			n.log.WithError(err).WithField("address", address).Error("Failed to get erc721 contract balanceOf address")
+	for _, client := range n.clients {
+		for _, address := range n.addresses {
+			err := n.getBalance(ctx, client, address)
+			if err != nil {
+				n.log.WithError(err).WithFields(logrus.Fields{
+					"address":   address,
+					"execution": client.Name(),
+				}).Error("Failed to get erc721 contract balanceOf address")
+			}
 		}
 	}
 }
 
-func (n *ERC721) getLabelValues(address *AddressERC721) []string {
+func (n *ERC721) getLabelValues(address *AddressERC721, executionName string) []string {
 	values := make([]string, len(n.labelsMap))
 
 	for label, index := range n.labelsMap {
@@ -127,6 +136,8 @@ func (n *ERC721) getLabelValues(address *AddressERC721) []string {
 				values[index] = address.Address
 			case LabelContract:
 				values[index] = address.Contract
+			case LabelExecution:
+				values[index] = executionName
 			default:
 				values[index] = LabelDefaultValue
 			}
@@ -136,19 +147,19 @@ func (n *ERC721) getLabelValues(address *AddressERC721) []string {
 	return values
 }
 
-func (n *ERC721) getBalance(address *AddressERC721) error {
+func (n *ERC721) getBalance(ctx context.Context, client api.ExecutionClient, address *AddressERC721) error {
 	var err error
 
 	defer func() {
 		if err != nil {
-			n.ERC721Error.WithLabelValues(n.getLabelValues(address)...).Inc()
+			n.ERC721Error.WithLabelValues(n.getLabelValues(address, client.Name())...).Inc()
 		}
 	}()
 
 	// call balanceOf(address) which is 0x70a08231
 	balanceOfData := "0x70a08231000000000000000000000000" + address.Address[2:]
 
-	balanceStr, err := n.client.ETHCall(&api.ETHCallTransaction{
+	balanceStr, err := client.ETHCall(ctx, &api.ETHCallTransaction{
 		To:   address.Contract,
 		Data: &balanceOfData,
 	}, "latest")
@@ -156,7 +167,7 @@ func (n *ERC721) getBalance(address *AddressERC721) error {
 		return err
 	}
 
-	n.ERC721Balance.WithLabelValues(n.getLabelValues(address)...).Set(hexStringToFloat64(balanceStr))
+	n.ERC721Balance.WithLabelValues(n.getLabelValues(address, client.Name())...).Set(hexStringToFloat64(balanceStr))
 
 	return nil
 }

--- a/pkg/exporter/jobs/erc721_test.go
+++ b/pkg/exporter/jobs/erc721_test.go
@@ -2,6 +2,7 @@ package jobs
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -59,10 +60,10 @@ func TestERC721_getBalance(t *testing.T) {
 			log := logrus.New()
 			log.SetLevel(logrus.ErrorLevel)
 
-			namespace := "erc721_" + string(rune('a'+i))
+			namespace := "erc721_" + strconv.Itoa(i)
 
 			erc721 := NewERC721(
-				mockClient,
+				mockClients(mockClient),
 				log,
 				15*time.Second,
 				namespace,
@@ -70,7 +71,7 @@ func TestERC721_getBalance(t *testing.T) {
 				[]*AddressERC721{tt.address},
 			)
 
-			err := erc721.getBalance(tt.address)
+			err := erc721.getBalance(context.Background(), mockClient, tt.address)
 
 			if (err != nil) != tt.wantError {
 				t.Errorf("getBalance() error = %v, wantError %v", err, tt.wantError)
@@ -113,7 +114,7 @@ func TestERC721_tick(t *testing.T) {
 	}
 
 	erc721 := NewERC721(
-		mockClient,
+		mockClients(mockClient),
 		log,
 		15*time.Second,
 		"test_erc721_tick",
@@ -124,7 +125,7 @@ func TestERC721_tick(t *testing.T) {
 	ctx := context.Background()
 	erc721.tick(ctx)
 
-	// Each address requires 1 call (balanceOf)
+	// Each address requires 1 call (balanceOf), 1 client * 2 addresses
 	expectedCalls := len(addresses)
 	if len(mockClient.callLog) != expectedCalls {
 		t.Errorf("Expected %d RPC calls, got %d", expectedCalls, len(mockClient.callLog))
@@ -147,7 +148,7 @@ func TestERC721_getLabelValues(t *testing.T) {
 	}
 
 	erc721 := NewERC721(
-		&mockExecutionClient{},
+		mockClients(&mockExecutionClient{}),
 		log,
 		15*time.Second,
 		"test_erc721_labels",
@@ -155,7 +156,7 @@ func TestERC721_getLabelValues(t *testing.T) {
 		addresses,
 	)
 
-	labels := erc721.getLabelValues(addresses[0])
+	labels := erc721.getLabelValues(addresses[0], "mock-node")
 
 	if len(labels) != len(erc721.labelsMap) {
 		t.Errorf("Expected %d label values, got %d", len(erc721.labelsMap), len(labels))

--- a/pkg/exporter/jobs/multi_client_test.go
+++ b/pkg/exporter/jobs/multi_client_test.go
@@ -1,0 +1,296 @@
+package jobs
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter/api"
+)
+
+func TestAccount_MultiClient_QueriesAllNodes(t *testing.T) {
+	t.Parallel()
+
+	client1 := &mockExecutionClient{
+		name:                  "geth-1",
+		ethGetBalanceResponse: "0xde0b6b3a7640000", // 1 ETH
+	}
+
+	client2 := &mockExecutionClient{
+		name:                  "nethermind-1",
+		ethGetBalanceResponse: "0xde0b6b3a7640000",
+	}
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	clients := []api.ExecutionClient{client1, client2}
+
+	addresses := []*AddressAccount{
+		{
+			Name:    "Test Account",
+			Address: "0x1111111111111111111111111111111111111111",
+			Labels:  map[string]string{},
+		},
+	}
+
+	account := NewAccount(
+		clients,
+		log,
+		15*time.Second,
+		"multi_client_account",
+		map[string]string{},
+		addresses,
+	)
+
+	ctx := context.Background()
+	account.tick(ctx)
+
+	// Both clients should have been called
+	assert.Equal(t, 1, client1.ethGetBalanceCalls, "client1 should be called once")
+	assert.Equal(t, 1, client2.ethGetBalanceCalls, "client2 should be called once")
+
+	// Verify metrics have the execution label for each client
+	gethVal := testutil.ToFloat64(account.AccountBalance.WithLabelValues("Test Account", "0x1111111111111111111111111111111111111111", "geth-1"))
+	nethermindVal := testutil.ToFloat64(account.AccountBalance.WithLabelValues("Test Account", "0x1111111111111111111111111111111111111111", "nethermind-1"))
+
+	assert.Greater(t, gethVal, 0.0, "geth-1 metric should be set")
+	assert.Greater(t, nethermindVal, 0.0, "nethermind-1 metric should be set")
+	assert.InDelta(t, gethVal, nethermindVal, 1.0, "both nodes should report same balance")
+}
+
+func TestAccount_MultiClient_OneNodeFails(t *testing.T) {
+	t.Parallel()
+
+	client1 := &mockExecutionClient{
+		name:                  "geth-1",
+		ethGetBalanceResponse: "0xde0b6b3a7640000",
+	}
+
+	client2 := &mockExecutionClient{
+		name:               "broken-node",
+		ethGetBalanceError: errors.New("connection refused"),
+	}
+
+	client3 := &mockExecutionClient{
+		name:                  "nethermind-1",
+		ethGetBalanceResponse: "0xde0b6b3a7640000",
+	}
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	clients := []api.ExecutionClient{client1, client2, client3}
+
+	addresses := []*AddressAccount{
+		{
+			Name:    "Test Account",
+			Address: "0x1111111111111111111111111111111111111111",
+			Labels:  map[string]string{},
+		},
+	}
+
+	account := NewAccount(
+		clients,
+		log,
+		15*time.Second,
+		"multi_client_error",
+		map[string]string{},
+		addresses,
+	)
+
+	ctx := context.Background()
+	account.tick(ctx)
+
+	// All clients should have been attempted
+	assert.Equal(t, 1, client1.ethGetBalanceCalls, "client1 should be called")
+	assert.Equal(t, 1, client2.ethGetBalanceCalls, "broken client should be called")
+	assert.Equal(t, 1, client3.ethGetBalanceCalls, "client3 should still be called after client2 fails")
+
+	// Working nodes should have metrics
+	gethVal := testutil.ToFloat64(account.AccountBalance.WithLabelValues("Test Account", "0x1111111111111111111111111111111111111111", "geth-1"))
+	assert.Greater(t, gethVal, 0.0)
+
+	nethermindVal := testutil.ToFloat64(account.AccountBalance.WithLabelValues("Test Account", "0x1111111111111111111111111111111111111111", "nethermind-1"))
+	assert.Greater(t, nethermindVal, 0.0)
+
+	// Broken node should have error counter incremented
+	errVal := testutil.ToFloat64(account.AccountError.WithLabelValues("Test Account", "0x1111111111111111111111111111111111111111", "broken-node"))
+	assert.InDelta(t, 1.0, errVal, 0.01, "error counter should be incremented for broken node")
+}
+
+func TestAccount_MultiClient_DifferentBalances(t *testing.T) {
+	t.Parallel()
+
+	client1 := &mockExecutionClient{
+		name:                  "node-a",
+		ethGetBalanceResponse: "0xde0b6b3a7640000", // 1 ETH
+	}
+
+	client2 := &mockExecutionClient{
+		name:                  "node-b",
+		ethGetBalanceResponse: "0x1bc16d674ec80000", // 2 ETH
+	}
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	clients := []api.ExecutionClient{client1, client2}
+
+	addresses := []*AddressAccount{
+		{
+			Name:    "Divergent",
+			Address: "0x1111111111111111111111111111111111111111",
+			Labels:  map[string]string{},
+		},
+	}
+
+	account := NewAccount(
+		clients,
+		log,
+		15*time.Second,
+		"multi_client_diverge",
+		map[string]string{},
+		addresses,
+	)
+
+	ctx := context.Background()
+	account.tick(ctx)
+
+	nodeAVal := testutil.ToFloat64(account.AccountBalance.WithLabelValues("Divergent", "0x1111111111111111111111111111111111111111", "node-a"))
+	nodeBVal := testutil.ToFloat64(account.AccountBalance.WithLabelValues("Divergent", "0x1111111111111111111111111111111111111111", "node-b"))
+
+	// Different nodes report different balances — this is the whole point of multi-node
+	assert.NotEqual(t, nodeAVal, nodeBVal, "nodes should report different balances for consensus detection")
+	assert.InDelta(t, 1e18, nodeAVal, 1.0)
+	assert.InDelta(t, 2e18, nodeBVal, 1.0)
+}
+
+func TestERC20_MultiClient_QueriesAllNodes(t *testing.T) {
+	t.Parallel()
+
+	client1 := &mockExecutionClient{
+		name:              "node-1",
+		balanceOfResponse: "0x0000000000000000000000000000000000000000000000000000000005f5e100",
+	}
+
+	client2 := &mockExecutionClient{
+		name:              "node-2",
+		balanceOfResponse: "0x0000000000000000000000000000000000000000000000000000000005f5e100",
+	}
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	clients := []api.ExecutionClient{client1, client2}
+
+	addresses := []*AddressERC20{
+		{
+			Name:     "USDC",
+			Address:  "0x1111111111111111111111111111111111111111",
+			Contract: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+			Labels:   map[string]string{},
+		},
+	}
+
+	erc20 := NewERC20(
+		clients,
+		log,
+		15*time.Second,
+		"multi_client_erc20",
+		map[string]string{},
+		addresses,
+	)
+
+	ctx := context.Background()
+	erc20.tick(ctx)
+
+	// Each client should make 2 calls per address (balanceOf + symbol)
+	assert.Len(t, client1.callLog, 2, "node-1 should make 2 calls")
+	assert.Len(t, client2.callLog, 2, "node-2 should make 2 calls")
+}
+
+func TestAccount_Start_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	mockClient := &mockExecutionClient{
+		name:                  "node-1",
+		ethGetBalanceResponse: "0x0",
+	}
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	account := NewAccount(
+		mockClients(mockClient),
+		log,
+		50*time.Millisecond, // short interval for testing
+		"start_cancel",
+		map[string]string{},
+		[]*AddressAccount{
+			{Name: "test", Address: "0x1111111111111111111111111111111111111111", Labels: map[string]string{}},
+		},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		account.Start(ctx)
+		close(done)
+	}()
+
+	// Let at least one tick happen
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	// Start should return after context cancellation
+	select {
+	case <-done:
+		// Success - Start returned
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return after context cancellation")
+	}
+
+	require.GreaterOrEqual(t, mockClient.ethGetBalanceCalls, 1, "at least one tick should have run")
+}
+
+func TestAccount_ExecutionLabelInMetrics(t *testing.T) {
+	t.Parallel()
+
+	mockClient := &mockExecutionClient{
+		name:                  "my-custom-node",
+		ethGetBalanceResponse: "0xde0b6b3a7640000",
+	}
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	account := NewAccount(
+		mockClients(mockClient),
+		log,
+		15*time.Second,
+		"exec_label_test",
+		map[string]string{},
+		[]*AddressAccount{
+			{Name: "addr1", Address: "0x1111111111111111111111111111111111111111", Labels: map[string]string{}},
+		},
+	)
+
+	ctx := context.Background()
+	account.tick(ctx)
+
+	// Verify the execution label is set to the client name
+	val := testutil.ToFloat64(account.AccountBalance.WithLabelValues("addr1", "0x1111111111111111111111111111111111111111", "my-custom-node"))
+	assert.InDelta(t, 1e18, val, 1.0)
+
+	// Verify the metric count - should be exactly 1 series
+	count := testutil.CollectAndCount(&account.AccountBalance)
+	assert.Equal(t, 1, count)
+}

--- a/pkg/exporter/jobs/uniswap_pair.go
+++ b/pkg/exporter/jobs/uniswap_pair.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"time"
 
-	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter/api"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+
+	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter/api"
 )
 
 // UniswapPair exposes metrics for ethereum uniswap pair contract.
 type UniswapPair struct {
-	client             api.ExecutionClient
+	clients            []api.ExecutionClient
 	log                logrus.FieldLogger
 	UniswapPairBalance prometheus.GaugeVec
 	UniswapPairError   prometheus.CounterVec
@@ -28,6 +29,9 @@ type AddressUniswapPair struct {
 	Labels   map[string]string `yaml:"labels"`
 }
 
+// GetName returns the configured name of this address.
+func (a *AddressUniswapPair) GetName() string { return a.Name }
+
 const (
 	NameUniswapPair = "uniswap_pair"
 )
@@ -37,14 +41,15 @@ func (n *UniswapPair) Name() string {
 }
 
 // NewUniswapPair returns a new UniswapPair instance.
-func NewUniswapPair(client api.ExecutionClient, log logrus.FieldLogger, checkInterval time.Duration, namespace string, constLabels map[string]string, addresses []*AddressUniswapPair) UniswapPair {
+func NewUniswapPair(clients []api.ExecutionClient, log logrus.FieldLogger, checkInterval time.Duration, namespace string, constLabels map[string]string, addresses []*AddressUniswapPair) UniswapPair {
 	namespace += "_" + NameUniswapPair
 
 	labelsMap := map[string]int{
-		LabelName:     0,
-		LabelContract: 1,
-		LabelFrom:     2,
-		LabelTo:       3,
+		LabelName:      0,
+		LabelContract:  1,
+		LabelFrom:      2,
+		LabelTo:        3,
+		LabelExecution: 4,
 	}
 
 	for address := range addresses {
@@ -61,7 +66,7 @@ func NewUniswapPair(client api.ExecutionClient, log logrus.FieldLogger, checkInt
 	}
 
 	instance := UniswapPair{
-		client:        client,
+		clients:       clients,
 		log:           log.WithField("module", NameUniswapPair),
 		addresses:     addresses,
 		checkInterval: checkInterval,
@@ -105,17 +110,21 @@ func (n *UniswapPair) Start(ctx context.Context) {
 	}
 }
 
-//nolint:unparam // context will be used in the future
 func (n *UniswapPair) tick(ctx context.Context) {
-	for _, address := range n.addresses {
-		err := n.getBalance(address)
-		if err != nil {
-			n.log.WithError(err).WithField("address", address).Error("Failed to get uniswap pair balance")
+	for _, client := range n.clients {
+		for _, address := range n.addresses {
+			err := n.getBalance(ctx, client, address)
+			if err != nil {
+				n.log.WithError(err).WithFields(logrus.Fields{
+					"address":   address,
+					"execution": client.Name(),
+				}).Error("Failed to get uniswap pair balance")
+			}
 		}
 	}
 }
 
-func (n *UniswapPair) getLabelValues(address *AddressUniswapPair) []string {
+func (n *UniswapPair) getLabelValues(address *AddressUniswapPair, executionName string) []string {
 	values := make([]string, len(n.labelsMap))
 
 	for label, index := range n.labelsMap {
@@ -131,6 +140,8 @@ func (n *UniswapPair) getLabelValues(address *AddressUniswapPair) []string {
 				values[index] = address.From
 			case LabelTo:
 				values[index] = address.To
+			case LabelExecution:
+				values[index] = executionName
 			default:
 				values[index] = LabelDefaultValue
 			}
@@ -140,19 +151,19 @@ func (n *UniswapPair) getLabelValues(address *AddressUniswapPair) []string {
 	return values
 }
 
-func (n *UniswapPair) getBalance(address *AddressUniswapPair) error {
+func (n *UniswapPair) getBalance(ctx context.Context, client api.ExecutionClient, address *AddressUniswapPair) error {
 	var err error
 
 	defer func() {
 		if err != nil {
-			n.UniswapPairError.WithLabelValues(n.getLabelValues(address)...).Inc()
+			n.UniswapPairError.WithLabelValues(n.getLabelValues(address, client.Name())...).Inc()
 		}
 	}()
 
 	// call getReserves() which is 0x0902f1ac
 	getReservesData := "0x0902f1ac000000000000000000000000"
 
-	balanceStr, err := n.client.ETHCall(&api.ETHCallTransaction{
+	balanceStr, err := client.ETHCall(ctx, &api.ETHCallTransaction{
 		To:   address.Contract,
 		Data: &getReservesData,
 	}, "latest")
@@ -173,7 +184,7 @@ func (n *UniswapPair) getBalance(address *AddressUniswapPair) error {
 	toBalance := hexStringToFloat64("0x" + balanceStr[66:130])
 
 	balance := toBalance / fromBalance
-	n.UniswapPairBalance.WithLabelValues(n.getLabelValues(address)...).Set(balance)
+	n.UniswapPairBalance.WithLabelValues(n.getLabelValues(address, client.Name())...).Set(balance)
 
 	return nil
 }

--- a/pkg/exporter/jobs/uniswap_pair_test.go
+++ b/pkg/exporter/jobs/uniswap_pair_test.go
@@ -2,6 +2,7 @@ package jobs
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -50,10 +51,10 @@ func TestUniswapPair_getBalance(t *testing.T) {
 			log := logrus.New()
 			log.SetLevel(logrus.ErrorLevel)
 
-			namespace := "uniswap_" + string(rune('a'+i))
+			namespace := "uniswap_" + strconv.Itoa(i)
 
 			uniswap := NewUniswapPair(
-				mockClient,
+				mockClients(mockClient),
 				log,
 				15*time.Second,
 				namespace,
@@ -61,7 +62,7 @@ func TestUniswapPair_getBalance(t *testing.T) {
 				[]*AddressUniswapPair{tt.address},
 			)
 
-			err := uniswap.getBalance(tt.address)
+			err := uniswap.getBalance(context.Background(), mockClient, tt.address)
 
 			if (err != nil) != tt.wantError {
 				t.Errorf("getBalance() error = %v, wantError %v", err, tt.wantError)
@@ -106,7 +107,7 @@ func TestUniswapPair_tick(t *testing.T) {
 	}
 
 	uniswap := NewUniswapPair(
-		mockClient,
+		mockClients(mockClient),
 		log,
 		15*time.Second,
 		"test_uniswap_tick",
@@ -117,7 +118,7 @@ func TestUniswapPair_tick(t *testing.T) {
 	ctx := context.Background()
 	uniswap.tick(ctx)
 
-	// Each address requires 1 call (getReserves)
+	// Each address requires 1 call (getReserves), 1 client * 2 addresses
 	expectedCalls := len(addresses)
 	if len(mockClient.callLog) != expectedCalls {
 		t.Errorf("Expected %d RPC calls, got %d", expectedCalls, len(mockClient.callLog))
@@ -141,7 +142,7 @@ func TestUniswapPair_getLabelValues(t *testing.T) {
 	}
 
 	uniswap := NewUniswapPair(
-		&mockExecutionClient{},
+		mockClients(&mockExecutionClient{}),
 		log,
 		15*time.Second,
 		"test_uniswap_labels",
@@ -149,7 +150,7 @@ func TestUniswapPair_getLabelValues(t *testing.T) {
 		addresses,
 	)
 
-	labels := uniswap.getLabelValues(addresses[0])
+	labels := uniswap.getLabelValues(addresses[0], "mock-node")
 
 	if len(labels) != len(uniswap.labelsMap) {
 		t.Errorf("Expected %d label values, got %d", len(uniswap.labelsMap), len(labels))

--- a/pkg/exporter/jobs/utils.go
+++ b/pkg/exporter/jobs/utils.go
@@ -10,6 +10,7 @@ const (
 	LabelAddress      string = "address"
 	LabelContract     string = "contract"
 	LabelDefaultValue string = ""
+	LabelExecution    string = "execution"
 	LabelFrom         string = "from"
 	LabelName         string = "name"
 	LabelSymbol       string = "symbol"

--- a/pkg/exporter/jobs/utils_test.go
+++ b/pkg/exporter/jobs/utils_test.go
@@ -1,0 +1,108 @@
+package jobs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHexStringToFloat64(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected float64
+	}{
+		{
+			name:     "1 ETH in wei",
+			input:    "0xde0b6b3a7640000",
+			expected: 1e18,
+		},
+		{
+			name:     "zero",
+			input:    "0x0",
+			expected: 0,
+		},
+		{
+			name:     "100 ETH in wei",
+			input:    "0x56bc75e2d63100000",
+			expected: 1e20,
+		},
+		{
+			name:     "small value",
+			input:    "0xa",
+			expected: 10,
+		},
+		{
+			name:     "full 32-byte hex",
+			input:    "0x0000000000000000000000000000000000000000000000000000000005f5e100",
+			expected: 100000000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := hexStringToFloat64(tt.input)
+			assert.InDelta(t, tt.expected, result, 1.0)
+		})
+	}
+}
+
+func TestHexStringToString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+		wantErr  bool
+	}{
+		{
+			name: "ABI-encoded USDC",
+			// offset=32, length=4, data="USDC"
+			input:    "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000455534443000000000000000000000000000000000000000000000000000000",
+			expected: "USDC",
+		},
+		{
+			name: "ABI-encoded ETH with length 4",
+			// offset=32, length=4, data starts with "UTH\x00" due to hex encoding
+			input:    "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000455544800000000000000000000000000000000000000000000000000000000",
+			expected: "UTH\x00",
+		},
+		{
+			name: "ABI-encoded sUSDC-Vau with length 9",
+			// offset=32, length=9
+			input:    "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000973555344432d5661756c74000000000000000000000000000000000000000000",
+			expected: "sUSDC-Vau",
+		},
+		{
+			name: "ABI-encoded DAI with length 3",
+			// offset=32, length=3, data="DAI"
+			input:    "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000034441490000000000000000000000000000000000000000000000000000000000",
+			expected: "DAI",
+		},
+		{
+			name:    "invalid hex",
+			input:   "0xZZZZ",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := hexStringToString(tt.input)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/exporter/metrics.go
+++ b/pkg/exporter/metrics.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter/api"
 	"github.com/ethpandaops/ethereum-address-metrics-exporter/pkg/exporter/jobs"
-	"github.com/sirupsen/logrus"
 )
 
 // Metrics exposes Execution layer metrics.
@@ -30,19 +31,19 @@ type metrics struct {
 }
 
 // NewMetrics creates a new execution Metrics instance.
-func NewMetrics(client api.ExecutionClient, log logrus.FieldLogger, checkInterval time.Duration, namespace string, constLabels map[string]string, addresses *Addresses) Metrics {
+func NewMetrics(clients []api.ExecutionClient, log logrus.FieldLogger, checkInterval time.Duration, namespace string, constLabels map[string]string, addresses *Addresses) Metrics {
 	m := &metrics{
 		log:                      log,
-		accountMetrics:           jobs.NewAccount(client, log, checkInterval, namespace, constLabels, addresses.Account),
-		erc20Metrics:             jobs.NewERC20(client, log, checkInterval, namespace, constLabels, addresses.ERC20),
-		erc721Metrics:            jobs.NewERC721(client, log, checkInterval, namespace, constLabels, addresses.ERC721),
-		erc1155Metrics:           jobs.NewERC1155(client, log, checkInterval, namespace, constLabels, addresses.ERC1155),
-		erc4626Metrics:           jobs.NewERC4626(client, log, checkInterval, namespace, constLabels, addresses.ERC4626),
-		uniswapPairMetrics:       jobs.NewUniswapPair(client, log, checkInterval, namespace, constLabels, addresses.UniswapPair),
-		chainlinkDataFeedMetrics: jobs.NewChainlinkDataFeed(client, log, checkInterval, namespace, constLabels, addresses.ChainlinkDataFeed),
-		erc4337Metrics:           jobs.NewERC4337(client, log, checkInterval, namespace, constLabels, addresses.ERC4337),
+		accountMetrics:           jobs.NewAccount(clients, log, checkInterval, namespace, constLabels, addresses.Account),
+		erc20Metrics:             jobs.NewERC20(clients, log, checkInterval, namespace, constLabels, addresses.ERC20),
+		erc721Metrics:            jobs.NewERC721(clients, log, checkInterval, namespace, constLabels, addresses.ERC721),
+		erc1155Metrics:           jobs.NewERC1155(clients, log, checkInterval, namespace, constLabels, addresses.ERC1155),
+		erc4626Metrics:           jobs.NewERC4626(clients, log, checkInterval, namespace, constLabels, addresses.ERC4626),
+		uniswapPairMetrics:       jobs.NewUniswapPair(clients, log, checkInterval, namespace, constLabels, addresses.UniswapPair),
+		chainlinkDataFeedMetrics: jobs.NewChainlinkDataFeed(clients, log, checkInterval, namespace, constLabels, addresses.ChainlinkDataFeed),
+		erc4337Metrics:           jobs.NewERC4337(clients, log, checkInterval, namespace, constLabels, addresses.ERC4337),
 
-		enabledJobs: make(map[string]bool),
+		enabledJobs: make(map[string]bool, 8),
 	}
 
 	m.log.Info("Enabling address metrics")


### PR DESCRIPTION
## Summary

Replaces the single-node `execution:` config object with a list of nodes. Every tick, each job fans out to **all** configured execution nodes for **every** address. All emitted metrics gain an `execution` label so per-node values can be diffed in PromQL/Grafana for consensus checks.

> ⚠️ **Breaking change**: `execution:` is now a list. Existing single-object configs must be updated — see the migration example below.

## Motivation

Operators frequently run more than one EL client (geth + nethermind, primary + canary, etc.). Today this exporter can only point at one. Adding multi-node support lets a single exporter scrape balances/metrics from every node and surface divergence as part of normal observability — useful for fork detection, client-divergence alerts, and rollouts.

## Behaviour

- For each tick: `for client in nodes: for address in addresses: query`.
- Each query produces a metric series tagged with `execution="<node-name>"`.
- A failure on one node logs an error and increments that node's `*_error` counter; other nodes continue normally.
- This is **fan-out only** — no health check, no failover, no round-robin. By design: the use case is per-node visibility, not redundant single-endpoint behaviour.

## Config migration

**Before:**
```yaml
execution:
  url: "http://localhost:8545"
  timeout: 10s
  headers:
    authorization: "Basic abc123"
```

**After:**
```yaml
execution:
  - name: "geth-1"
    url: "http://localhost:8545"
    timeout: 10s
    headers:
      authorization: "Basic abc123"
  - name: "nethermind-1"
    url: "http://localhost:8546"
    timeout: 10s
```

Validation enforces `len(execution) >= 1`, non-empty names, and unique names.

## Implementation notes

- **Context propagation**: `ExecutionClient.ETHCall` / `ETHGetBalance` now take `ctx` as their first argument, threaded from each job's `tick(ctx)` into `http.NewRequestWithContext` — RPC calls now respect tick cancellation/timeouts.
- **Shared HTTP metrics**: `api.NewMetrics` is now constructed once in `exporter.Start` and the resulting `Metrics` instance is passed into every `NewExecutionClient`. Per-client construction would panic with `duplicate metrics collector registration attempted` once N > 1.
- **HTTP metric labels**: the `path` label is now just the URL path (default `/`) — extracted via `url.Parse` once at construction. Combined with the new `execution` label, this avoids leaking embedded credentials in label values and matches the labelling style of the rest of the metrics.
- **Config validation**: introduced a generic `checkDuplicateNames[T named]` helper plus a `GetName()` method on every `Address*` type. Replaces eight copy-pasted duplicate-check blocks.

## Tests

- New `pkg/exporter/api/api_test.go` — `ETHCall`, `ETHGetBalance`, custom headers, timeout, connection-refused.
- New `pkg/exporter/config_test.go` — validation rules including the new execution-node checks.
- New `pkg/exporter/jobs/multi_client_test.go` — verifies jobs query every configured node and emit per-node label values.
- New `pkg/exporter/jobs/utils_test.go` — hex helpers.
- Existing job tests updated for the new `ctx`-carrying signatures and `[]ExecutionClient` constructors. Mock client gains `Name()` and accepts `ctx`.

## Tooling / hygiene

- Lint config refresh (`.golangci.yml`): added `cyclop`, `funlen`, `gocognit`, `gocritic`, `errorlint`, `modernize`, `perfsprint`, `revive`, `testifylint`, `usetesting`; dropped `nlreturn`, `wsl_v5`, `decorder`, `dogsled` and others. Switched formatter to `gofumpt` with `goimports` local-prefix.
- Go 1.26.1 (`go.mod` + Dockerfile builder image).
- Added `stretchr/testify` dependency.
- Style sweeps from new linters: `interface{}` → `any`, `fmt.Sprintf("%d")` → `strconv.Itoa`, shadowed-err renames, godoc on exported types, README EIP link fixes.

## What this PR does **not** add

For transparency — these are real follow-ups, not part of this change:
- Health checks / circuit breaker
- Failover or primary/secondary semantics
- Round-robin or load distribution across nodes
- Parallelism within a tick (per-node fan-out is currently serial)
- Authoritative "chosen" value across nodes

Happy to scope any of these as a follow-up if useful.

## Test plan

- [ ] `go build ./...` (passes locally)
- [ ] `go test ./...` (passes locally)
- [ ] `golangci-lint run ./...` (0 issues locally)
- [ ] Run with a config containing two execution nodes and verify `/metrics` exposes `{execution="node-a"}` and `{execution="node-b"}` series for at least one address job
- [ ] Verify `eth_address_http_request_count{execution="..."}` series appear with the path-only `path` label
- [ ] Stop one execution node mid-run and confirm errors are logged + `*_error` increments only for that node, while the other continues to update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
